### PR TITLE
fix package publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -86,14 +86,14 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      # Update jsr.json version to match package.json
+      # Update deno.json version to match package.json (JSR uses deno.json)
       - name: Update JSR version
         run: |
           current_version=$(node -p "require('./package.json').version")
           node -e "
-            const jsr = require('./jsr.json');
-            jsr.version = '$current_version';
-            require('fs').writeFileSync('jsr.json', JSON.stringify(jsr, null, 2));
+            const deno = require('./deno.json');
+            deno.version = '$current_version';
+            require('fs').writeFileSync('deno.json', JSON.stringify(deno, null, 2));
           "
 
       # Publish to JSR using pnpx (no Deno setup needed)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -90,10 +90,19 @@ jobs:
       - name: Update JSR version
         run: |
           current_version=$(node -p "require('./package.json').version")
+          # Use Node.js to safely update version without breaking JSONC comments
           node -e "
-            const deno = require('./deno.json');
-            deno.version = '$current_version';
-            require('fs').writeFileSync('deno.json', JSON.stringify(deno, null, 2));
+            const fs = require('fs');
+            const version = '$current_version';
+            let content = fs.readFileSync('deno.json', 'utf8');
+            if (content.includes('\"version\"')) {
+              // Update existing version field
+              content = content.replace(/\"version\":\s*\"[^\"]*\"/, '\"version\": \"' + version + '\"');
+            } else {
+              // Add version field after name field
+              content = content.replace(/(\"name\":\s*\"[^\"]*\")/, '$1,\n  \"version\": \"' + version + '\"');
+            }
+            fs.writeFileSync('deno.json', content);
           "
 
       # Publish to JSR using pnpx (no Deno setup needed)

--- a/docs/auto-publishing-setup.md
+++ b/docs/auto-publishing-setup.md
@@ -66,19 +66,41 @@ git push origin feature-branch
 - ✅ Creates git tags for published versions
 - ✅ Uses `pnpm` as specified in project requirements
 
-## Configuration Details
+## Configuration Files
 
-### Package.json
-Already configured with:
-- Proper exports for multiple entry points (node, browser, deno, bun)
-- Public access for npm publishing
-- Build scripts using pnpm
+This project uses multiple configuration files for different purposes:
 
-### JSR.json
-Already configured with:
-- Scoped name `@logan/logger`
-- Proper exports and includes
-- Version will be auto-synced from package.json
+### `package.json` - npm & Version Source of Truth
+- **Primary purpose**: npm publishing and version management
+- **Package name**: `logan-logger`
+- **Version control**: Use `pnpm version patch/minor/major` to bump
+- **Exports**: Multiple entry points (node, browser, deno, bun)
+- **Build scripts**: Uses pnpm commands
+
+### `deno.json` - JSR Primary Configuration
+- **Primary purpose**: JSR publishing and Deno runtime configuration
+- **Package name**: `@logan/logger`
+- **Version**: Auto-synced from package.json during publishing
+- **Exports**: Points to TypeScript source files
+- **Deno tasks**: Test and check commands for Deno development
+
+### `jsr.json` - JSR Metadata (Optional)
+- **Primary purpose**: Additional JSR metadata and documentation
+- **Contains**: Description, keywords, license, author info
+- **Version**: Not needed - JSR reads from deno.json
+- **Status**: Kept for clarity but JSR uses deno.json as primary config
+
+### Why Multiple Files?
+
+**JSR Configuration Hierarchy:**
+1. JSR reads `deno.json` first (Deno team's preference)
+2. Falls back to `jsr.json` if deno.json missing
+3. Can fallback to `package.json` for Node.js packages
+
+**Our Strategy:**
+- `package.json` = single source of truth for version
+- `deno.json` = gets version synced automatically during CI
+- `jsr.json` = optional metadata file for documentation
 
 ## Workflow Behavior
 


### PR DESCRIPTION
JSR publish failed, so changing to use version in deno.json

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches the publish workflow to sync JSR version from package.json into deno.json and updates docs to reflect deno.json as the primary JSR config with a clarified config hierarchy.
> 
> - **CI/Workflow (`.github/workflows/publish.yml`)**:
>   - Update JSR version sync to write `package.json` version into `deno.json` (was `jsr.json`).
>   - Adjust inline comment to note JSR uses `deno.json`.
> - **Docs (`docs/auto-publishing-setup.md`)**:
>   - Replace configuration section with a concise overview of `package.json` (version source), `deno.json` (JSR primary config), and `jsr.json` (optional metadata), including JSR config hierarchy and project strategy.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 43546f5e318fdec5b6bca1b73182590eb5dd5c92. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->