### PR TITLE
fix: specify pnpm version in auto-release workflow

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -24,6 +24,8 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
+        with:
+          version: latest
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -118,6 +120,8 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
+        with:
+          version: latest
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary
- Fixes failing auto-release workflow by adding `version: latest` to both `pnpm/action-setup@v4` steps
- The pnpm v4 action requires either an explicit version in the action config or a `packageManager` field in `package.json`; this project has neither

## Changes

### Bug Fixes
- **.github/workflows/auto-release.yml**: Add `version: latest` to both `pnpm/action-setup@v4` steps

## Test plan
- [ ] Merge a PR and verify the auto-release workflow completes successfully without the pnpm setup error