### PR TITLE
fix: unblock releases and stop JSR rewriting the winston import

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -36,7 +36,13 @@ jobs:
       - name: Determine next version
         id: version
         run: |
-          latest_tag=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          # Use the highest semver tag in the repo, not `git describe`.
+          # `git describe` only sees tags reachable from HEAD, so a reverted
+          # release bump leaves it pointing at an older tag and we recompute a
+          # version that was already published. Filtering on vN.N.N also skips
+          # malformed tags left behind by failed runs.
+          latest_tag=$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -n1)
+          [ -z "$latest_tag" ] && latest_tag="v0.0.0"
           echo "latest=$latest_tag" >> "$GITHUB_OUTPUT"
 
           version="${latest_tag#v}"
@@ -59,6 +65,11 @@ jobs:
           echo "next=$next" >> "$GITHUB_OUTPUT"
           echo "version=${major}.${minor}.${patch}" >> "$GITHUB_OUTPUT"
           echo "Next version: $next (from $latest_tag)"
+
+          if git rev-parse -q --verify "refs/tags/$next" >/dev/null; then
+            echo "::error::Tag $next already exists. Refusing to republish." >&2
+            exit 1
+          fi
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@logan/logger",
-  "version": "1.1.15",
+  "version": "1.1.16",
   "exports": "./src/index.ts",
   "compilerOptions": {
     "allowJs": true,

--- a/docs/jsr-winston-import-bug.md
+++ b/docs/jsr-winston-import-bug.md
@@ -1,0 +1,93 @@
+# JSR Winston Import Bug
+
+## Symptom
+
+Consumers installing `@logan/logger` from JSR (e.g., `pnpm add jsr:@logan/logger`)
+see this warning at runtime, even when `winston` is installed as a peer dep:
+
+```
+[logan-logger] Winston not found, falling back to console logging:
+Error [ERR_MODULE_NOT_FOUND]: Cannot find module
+'/path/to/node_modules/.pnpm/@jsr+logan__logger@1.1.x/node_modules/@jsr/logan__logger/src/runtime/winston'
+imported from .../@jsr/logan__logger/src/runtime/node.js
+```
+
+The logger silently falls back to console output even though Winston is
+available, so file transports / production formatting are lost.
+
+## Root Cause
+
+`src/runtime/node.ts` did this:
+
+```ts
+const winston = await import('winston');
+```
+
+JSR's publish pipeline statically analyzes ESM imports. Bare specifiers must be
+explicitly mapped to a known JSR/npm specifier (e.g., `npm:winston`). Because
+`winston` was not declared in `jsr.json` / `deno.json` `imports`, JSR rewrote
+the bare specifier `'winston'` to a relative file path `'./winston'` during
+publish. Verified by inspecting the published tarball at
+`https://npm.jsr.io/~/11/@jsr/logan__logger/1.1.16.tgz`:
+
+```ts
+// inside the published src/runtime/node.ts
+const winston = await import('./winston');
+```
+
+At runtime Node tries to resolve `./winston` relative to the package, finds no
+such file, throws `ERR_MODULE_NOT_FOUND`, and the catch block triggers the
+console fallback.
+
+The npm distribution (`logan-logger`) is unaffected because Vite externalizes
+`winston` correctly during the bundler build. The bug only impacts the JSR
+distribution.
+
+## Affected Versions
+
+All published JSR versions through **1.1.16** at minimum. The
+`fix(node): handle optional Winston dependency with TypeScript ignore` commit
+(`2a18f6f`, 2025-12-03) only added `// @ts-ignore` comments — it did not change
+the import statement and so did not address this bug.
+
+## Fix
+
+Use a dynamic specifier so JSR's static analyzer cannot rewrite the import:
+
+```ts
+private async initializeWinston(): Promise<void> {
+  try {
+    // Dynamic specifier prevents JSR from rewriting the bare 'winston'
+    // import to a relative './winston' path during publish.
+    const winstonModule = 'winston';
+    const winston = await import(winstonModule);
+    this.winston = this.createWinstonLogger(winston);
+  } catch (error) {
+    console.warn('[logan-logger] Winston not found, falling back to console logging:', error);
+  }
+}
+```
+
+This works in every supported runtime:
+
+| Runtime | Behavior |
+|---------|----------|
+| Node + winston installed | Resolves normally via npm package lookup |
+| Node without winston | Throws `ERR_MODULE_NOT_FOUND`, caught, falls back to console |
+| Deno / Bun (no winston) | Throws unknown specifier, caught, falls back to console |
+| JSR publish pipeline | Cannot statically analyze the dynamic specifier — leaves it alone |
+
+An alternative fix would be to declare `winston` as an `npm:` specifier in
+`deno.json` / `jsr.json` `imports`, but that ties JSR consumers to a specific
+npm package and breaks the "optional peer" semantics.
+
+## Verification Steps
+
+1. Apply the fix to `src/runtime/node.ts`.
+2. Run `pnpm test` — all 170+ tests should still pass (the existing
+   `node-logger` tests cover the winston-detection path).
+3. Bump version (e.g., `make bump-patch`) so JSR publishes a new tarball.
+4. Tag and push to trigger the auto-publish workflow.
+5. In a consumer project that installs from JSR + has `winston` in
+   `dependencies`, confirm no `[logan-logger] Winston not found` warning at
+   runtime.

--- a/jsr.json
+++ b/jsr.json
@@ -2,7 +2,7 @@
   "name": "@logan/logger",
   "author": "Logan Lindquist Land",
   "license": "MIT",
-  "version": "1.1.15",
+  "version": "1.1.16",
   "description": "Universal TypeScript logging library for all JavaScript runtimes",
   "exports": {
     ".": "./src/index.ts"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logan-logger",
-  "version": "1.1.15",
+  "version": "1.1.16",
   "description": "Universal TypeScript logging library for all JavaScript runtimes",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/src/runtime/node.ts
+++ b/src/runtime/node.ts
@@ -13,10 +13,15 @@ export class NodeLogger extends BaseLogger {
 
   private async initializeWinston(): Promise<void> {
     try {
-      // Try to load Winston if available (optional peer dependency)
+      // Try to load Winston if available (optional peer dependency).
+      // Use a dynamic specifier so JSR's publish pipeline won't rewrite the
+      // bare import 'winston' to a relative './winston' path. This keeps
+      // resolution at runtime, where Node will find the npm package if
+      // installed and throw harmlessly otherwise.
+      const winstonModule = 'winston';
       // biome-ignore lint/suspicious/noTsIgnore: Winston optional dependency - error only exists in CI without Winston
       // @ts-ignore - Winston is an optional peer dependency, may not be installed in all environments
-      const winston = await import('winston');
+      const winston = await import(winstonModule);
       this.winston = this.createWinstonLogger(winston);
     } catch (error) {
       // Winston not available, will fall back to console


### PR DESCRIPTION
## Summary
- `auto-release.yml` would recompute an already-published `v1.1.16` because commit e9ed165 reverted the version bump, leaving that tag unreachable from HEAD via `git describe --tags`
- Switched the workflow to derive the previous version from the highest semver tag in the repo instead
- Synced `package.json`, `jsr.json`, and `deno.json` to `1.1.16` to match what is actually published on npm
- JSR's publish pipeline was statically rewriting the bare `await import('winston')` to a relative `./winston` path, breaking Winston detection for every JSR consumer even when Winston was installed
- Fixed by assigning the specifier to a variable first so JSR's analyzer cannot resolve it and leaves the import alone

## Changes

### CI Fix
- **.github/workflows/auto-release.yml**: Derive the previous version from `git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname` instead of `git describe --tags`, so it isn't fooled by a reverted bump commit leaving the latest tag unreachable from HEAD. Filtering on `v[0-9]*.[0-9]*.[0-9]*` also excludes malformed tags left by failed runs (there is one named `v{`). Added a guard that fails the run early if the computed release tag already exists.

### Version Sync
- **package.json**: Bump to `1.1.16` to match the published npm package
- **jsr.json**: Bump to `1.1.16` to match the published npm package
- **deno.json**: Bump to `1.1.16` to match the published npm package

With this change, the next computed release is `v1.1.17`.

This unblocks #42, #43, and #44, none of which can ship until releases work again.

Closes #45

### JSR Winston Import Fix
- **src/runtime/node.ts**: Assign the `winston` specifier to a variable before the dynamic `import()` call, so JSR's publish-time static analyzer can no longer rewrite the bare specifier to a relative `./winston` path. Resolution now happens purely at runtime — Node finds the npm package when it's installed and throws harmlessly (caught, falling back to console logging) when it isn't.
- **docs/jsr-winston-import-bug.md**: Investigation notes documenting the symptom, root cause (verified against the published JSR tarball for `1.1.16`), affected versions (all published JSR versions through 1.1.16 — the npm distribution was never affected since Vite externalizes winston during the build), the fix, and verification steps.

Closes #42

## Verification
Ran locally: typecheck clean, biome lint clean, 170 tests passed / 7 skipped.

## Test plan
- [ ] Confirm `git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname` returns `v1.1.16` as the highest tag with the malformed `v{` tag excluded
- [ ] Merge to main and confirm auto-release computes `v1.1.17`, not `v1.1.16`
- [ ] Confirm the new tag-exists guard fails the run early if it were to compute an already-existing tag
- [ ] Confirm publish.yml successfully tags, publishes to npm, and publishes to JSR for `v1.1.17`
- [ ] In a consumer project that installs `@logan/logger` from JSR with `winston` as a dependency, confirm no `[logan-logger] Winston not found` warning appears at runtime
