### PR TITLE
fix(serialization): unify the two disagreeing error serializers

### DIFF
--- a/src/utils/serialization.ts
+++ b/src/utils/serialization.ts
@@ -20,21 +20,10 @@ export function safeStringify(obj: any, space?: number): string {
         seen.add(value);
       }
 
-      // Handle Error objects
+      // Handle Error objects. Delegates to the single shared serializer below
+      // so that safeStringify and serializeError cannot drift apart.
       if (value instanceof Error) {
-        return {
-          name: value.name,
-          message: value.message,
-          stack: value.stack,
-          ...Object.getOwnPropertyNames(value).reduce((acc, prop) => {
-            if (prop !== 'name' && prop !== 'message' && prop !== 'stack') {
-              // biome-ignore lint/suspicious/noExplicitAny: Dynamic property access on Error
-              acc[prop] = (value as any)[prop];
-            }
-            return acc;
-            // biome-ignore lint/suspicious/noExplicitAny: Accumulator for dynamic properties
-          }, {} as any),
-        };
+        return serializeError(value);
       }
 
       // Handle functions
@@ -118,16 +107,59 @@ export function filterSensitiveData(
  * // Result: { name: 'Error', message: 'Something went wrong', stack: '...' }
  * ```
  */
+/**
+ * Properties emitted first, in this order, and never overwritable by a
+ * same-named own property on the error.
+ */
+const ERROR_CORE_PROPERTIES = ['name', 'message', 'stack'];
+
+/**
+ * Read a single own property off an error without letting it break
+ * serialization. Accessor properties run user code, which may throw.
+ */
+function readErrorProperty(error: Error, property: string): unknown {
+  const descriptor = Object.getOwnPropertyDescriptor(error, property);
+
+  if (!descriptor) {
+    return undefined;
+  }
+
+  if (descriptor.get) {
+    try {
+      return descriptor.get.call(error);
+    } catch {
+      return '[Throws]';
+    }
+  }
+
+  return descriptor.value;
+}
+
 // biome-ignore lint/suspicious/noExplicitAny: Error serialization accepts arbitrary error types
 export function serializeError(error: any): any {
-  if (error instanceof Error) {
-    return {
-      name: error.name,
-      message: error.message,
-      stack: error.stack,
-      // biome-ignore lint/suspicious/noExplicitAny: Spread Error to capture custom properties
-      ...(error as any), // Include any additional properties
-    };
+  if (!(error instanceof Error)) {
+    return error;
   }
-  return error;
+
+  const serialized: Record<string, unknown> = {
+    name: error.name,
+    message: error.message,
+  };
+
+  // Omit `stack` entirely when unavailable rather than emitting null.
+  if (error.stack !== undefined) {
+    serialized.stack = error.stack;
+  }
+
+  // All own properties, not just enumerable ones. `message` and `stack` are
+  // non-enumerable on a standard Error, so a spread would silently drop
+  // anything defined the same way.
+  for (const property of Object.getOwnPropertyNames(error)) {
+    if (ERROR_CORE_PROPERTIES.includes(property)) {
+      continue;
+    }
+    serialized[property] = readErrorProperty(error, property);
+  }
+
+  return serialized;
 }

--- a/tests/serialization.test.ts
+++ b/tests/serialization.test.ts
@@ -298,5 +298,94 @@ describe('Serialization Utilities', () => {
 
       expect(serialized).toEqual(errorLike);
     });
+
+    it('should include non-enumerable own properties', () => {
+      const error = new Error('hidden');
+      Object.defineProperty(error, 'code', {
+        value: 'E_HIDDEN',
+        enumerable: false,
+        configurable: true,
+      });
+
+      const serialized = serializeError(error);
+
+      expect(serialized.code).toBe('E_HIDDEN');
+    });
+
+    it('should not let an own property overwrite name, message or stack', () => {
+      const error = new Error('the real message') as any;
+      Object.defineProperty(error, 'name', { value: 'Impostor', enumerable: true });
+
+      const serialized = serializeError(error);
+
+      expect(serialized.name).toBe('Impostor');
+      expect(serialized.message).toBe('the real message');
+      expect(Object.keys(serialized).filter((k) => k === 'name')).toHaveLength(1);
+    });
+
+    it('should emit name, message and stack first, in that order', () => {
+      const error = new Error('ordered') as any;
+      error.zzz = 1;
+      error.aaa = 2;
+
+      expect(Object.keys(serializeError(error)).slice(0, 3)).toEqual([
+        'name',
+        'message',
+        'stack',
+      ]);
+    });
+
+    it('should omit stack entirely when it is undefined', () => {
+      const error = new Error('no stack');
+      error.stack = undefined;
+
+      const serialized = serializeError(error);
+
+      expect('stack' in serialized).toBe(false);
+    });
+
+    it('should not throw when reading a getter that throws', () => {
+      const error = new Error('boom');
+      Object.defineProperty(error, 'exploding', {
+        get() {
+          throw new Error('getter blew up');
+        },
+        enumerable: true,
+        configurable: true,
+      });
+
+      expect(() => serializeError(error)).not.toThrow();
+      expect(serializeError(error).exploding).toBe('[Throws]');
+      expect(() => safeStringify({ err: error })).not.toThrow();
+    });
+
+    it('should include an ES2022 cause', () => {
+      const cause = new Error('underlying');
+      const error = new Error('wrapper', { cause });
+
+      const serialized = serializeError(error);
+
+      expect(serialized.cause).toBe(cause);
+    });
+
+    it('should agree with safeStringify for the same error', () => {
+      const build = () => {
+        const error = new Error('shared') as any;
+        error.stack = 'STACK';
+        error.enumerableProp = 'a';
+        Object.defineProperty(error, 'hiddenProp', {
+          value: 'b',
+          enumerable: false,
+          configurable: true,
+        });
+        return error;
+      };
+
+      // The two paths disagreed before they were unified: serializeError
+      // spread only enumerable own properties and so dropped hiddenProp.
+      expect(JSON.parse(safeStringify(build()))).toEqual(
+        JSON.parse(JSON.stringify(serializeError(build())))
+      );
+    });
   });
 });


### PR DESCRIPTION
## Summary
- `safeStringify` and `serializeError` each had their own Error handling and produced different output for the same input, and `safeStringify` now delegates to `serializeError` so the two paths cannot drift apart again.
- Several behavior changes fix real gaps in error serialization: non-enumerable own properties are now included, the core `name`/`message`/`stack` fields can no longer be silently overwritten, `stack` is omitted rather than emitted as `null` when undefined, throwing getters no longer break serialization, and `Error.cause` is now included.
- This is a PATCH release and will cut v1.1.21 on merge.

## The problem

`safeStringify` enumerated `Object.getOwnPropertyNames`. `serializeError` spread the error, which copies only enumerable own properties. Since `message` and `stack` are non-enumerable on a standard `Error`, and any property defined via `Object.defineProperty` is non-enumerable by default, the two disagreed on real inputs:

```
OLD serializeError keys: [name, message, stack, enumerableProp]
  hiddenProp present?    false
```

`serializeError` also placed its spread after the explicit fields, so an own property named `name`, `message`, or `stack` silently overwrote the canonical value:

```
OLD message clobber:     CLOBBERED
```

`safeStringify` already guarded against that; `serializeError` did not.

## The fix

There is now one serializer. `safeStringify` delegates to `serializeError`, so the two cannot drift apart again. Key order is `name`, `message`, `stack`, then remaining own properties, and the first three are never overwritable.

## Changes

### Fixes
- **src/utils/serialization.ts**: Unify `safeStringify` and `serializeError` into a single Error-serialization path. `stack` is now omitted entirely when `undefined` rather than emitted as `null`. Accessor properties are read through a guard, so a getter that throws yields `"[Throws]"` instead of breaking serialization outright. ES2022 `Error.cause` is an own non-enumerable property and is now included, where the previous spread-based approach dropped it.

### Tests
- **tests/serialization.test.ts**: Adds seven regression tests, including one asserting the two paths produce identical output for an error carrying both enumerable and non-enumerable properties.

## Verification
- 177 tests pass / 7 skipped (up from 170; seven added)
- `just typecheck` clean
- `just lint` (biome) clean
- `just build` clean

## Notes
- This is a PATCH release and will cut v1.1.21 on merge.
- This unblocks #57, whose traversal rewrite should consume this single serializer rather than reintroducing an inline copy.

Closes #59
