### PR TITLE
feat!: 2.0.0 — remove Winston, own the transports, fix cycle detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,15 @@
 
 A universal TypeScript logging library that works consistently across all JavaScript runtimes: Node.js, Deno, Bun, browsers, and WebAssembly environments.
 
+> **Upgrading from 1.x?** See the [2.0 migration guide](./docs/migration-2.0.md).
+> Winston is gone, file logging is opt-in, and repeated object references are no
+> longer reported as `[Circular]`.
+
 ## Features
 
 - 🌐 **Universal Runtime Support** - Works in Node.js, Deno, Bun, browsers, and WebAssembly
 - ⚛️ **Next.js Ready** - Full compatibility with App Router, Server Components, and API Routes
-- 🪶 **Zero Dependencies** - Core functionality with no required dependencies
+- 🪶 **Zero Dependencies** - No dependencies at all, required or optional, on any runtime
 - ⚡ **Performance First** - Lazy evaluation, zero-allocation logging, minimal memory footprint
 - 🎯 **TypeScript Native** - Full type safety with comprehensive type definitions
 - 🔧 **Flexible Configuration** - Environment-based auto-configuration or manual setup
@@ -170,19 +174,35 @@ const logger = createLoggerForEnvironment();
 
 Logan Logger provides runtime-specific entry points for optimal bundling and type safety:
 
-**🟢 Node.js with Winston Support:**
+**🟢 Node.js with file logging:**
 ```typescript
-import { createLogger, NodeLogger, createMorganStream } from 'logan-logger/node';
+import { createLogger, LogLevel, NodeLogger, createMorganStream } from 'logan-logger/node';
 
 const logger = new NodeLogger({
   transports: [
-    { type: 'file', options: { filename: 'app.log' } }
+    { type: 'console', options: {} },
+    {
+      type: 'file',
+      level: LogLevel.ERROR,
+      options: { filename: 'logs/error.log', maxsize: 5_242_880, maxFiles: 5 }
+    }
   ]
 });
 
 // Express/Morgan integration
 app.use(morgan('combined', { stream: createMorganStream(logger) }));
 ```
+
+File logging is **opt-in**: with no `transports` configured a logger writes to the
+console and nowhere else, whatever `NODE_ENV` says. The log directory is created
+lazily on the first write, so a logger that is configured but never used touches
+the disk zero times.
+
+The `file` transport is registered by the `logan-logger/node` and
+`logan-logger/bun` entry points. It is deliberately absent from the main
+`logan-logger` entry so that `node:fs` never reaches a browser bundle — configure
+a file transport from the main entry and you get a warning telling you which
+entry point to import instead.
 
 **🌐 Browser-Optimized (Webpack/Vite-Safe):**
 ```typescript
@@ -240,7 +260,7 @@ logger.info('User processed', safeData);
 | Runtime | Import Path | Status | Implementation | Features |
 |---------|-------------|--------|----------------|----------|
 | **Next.js 13+** | `logan-logger` | ✅ **Full** | **Auto-detection** | **Server/Client Components, API Routes, Edge Runtime** |
-| Node.js 20+ | `logan-logger/node` | ✅ Full | Winston + Console | File logging, transports, Morgan integration |
+| Node.js 20+ | `logan-logger/node` | ✅ Full | Console + File transports | File logging with size rotation, custom transports, Morgan integration |
 | Bun | `logan-logger/bun` | ✅ Full | NodeLogger adapter | Same as Node.js |
 | Browser | `logan-logger/browser` | ✅ Full | Console API | CSS styling, performance marks, grouping |
 | Deno | `@logan/logger/deno` (JSR) | ✅ Basic | BrowserLogger adapter | Console logging (native implementation planned) |
@@ -280,6 +300,56 @@ interface LoggerConfig {
   metadata: Record<string, any>;
   transports?: TransportConfig[];
 }
+```
+
+`timestamp` and `colorize` apply to the **text** form only. The JSON envelope
+always carries a timestamp and is never colorized, so a structured log stream
+stays parseable. `colorize` additionally defers to the terminal: ANSI escapes are
+suppressed when stdout is not a TTY, and the `NO_COLOR` / `FORCE_COLOR`
+conventions are honored.
+
+### Transports
+
+`transports` lists exactly where records go, in order. Omit it and you get the
+console alone.
+
+```typescript
+import { LogLevel, NodeLogger } from 'logan-logger/node';
+
+const logger = new NodeLogger({
+  transports: [
+    { type: 'console', options: { format: 'text', colorize: true } },
+    { type: 'file', level: LogLevel.ERROR, options: { filename: 'logs/error.log' } }
+  ]
+});
+```
+
+| Type | Available from | Options |
+|---|---|---|
+| `console` | everywhere | `format`, `timestamp`, `colorize` |
+| `file` | `logan-logger/node`, `logan-logger/bun` | `filename`, `maxsize`, `maxFiles`, `format`, `timestamp` |
+| `custom` | everywhere | `transport` — any object with a `write(entry)` method |
+
+Each transport is constructed behind its own guard: one failing to initialize
+warns and is dropped, and the rest keep working. The same applies at write time.
+
+A child logger **shares** its parent's transport instances, so
+`logger.child({ requestId })` per request costs no extra file handles.
+
+Plug in your own destination either inline:
+
+```typescript
+const logger = new NodeLogger({
+  transports: [{ type: 'custom', options: { transport: { type: 'syslog', write(entry) { /* … */ } } } }]
+});
+```
+
+or by name, so it can be selected from configuration:
+
+```typescript
+import { registerTransport } from 'logan-logger';
+
+registerTransport('syslog', (config, context) => new SyslogTransport(config.options));
 ```
 
 ## API Reference

--- a/README.md
+++ b/README.md
@@ -284,9 +284,15 @@ enum LogLevel {
 ```bash
 LOG_LEVEL=debug      # debug, info, warn, error, silent
 LOG_FORMAT=json      # json, text
-LOG_TIMESTAMP=true   # true, false
-LOG_COLOR=false      # true, false
+LOG_TIMESTAMP=true   # true/1/yes/on, false/0/no/off
+LOG_COLOR=false      # true/1/yes/on, false/0/no/off
 ```
+
+These sit at the **top** of the precedence chain — above configuration passed to
+`createLogger()` — so an operator can change logging on a running service without
+a deploy. Opt out with `createLogger({ ..., ignoreEnvironment: true })`. A value
+that does not parse is ignored with a warning rather than silently resolving to a
+default.
 
 > **📋 See [Environment Variables Documentation](./docs/environment-variables.md) for complete details, examples, and runtime-specific considerations.**
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -53,7 +53,7 @@ LOG_FORMAT=text
 **Controls whether timestamps are included in log output.**
 
 **Variable:** `LOG_TIMESTAMP`  
-**Values:** `true`, `false`  
+**Values:** `true`, `1`, `yes`, `on` / `false`, `0`, `no`, `off` (case-insensitive)  
 **Default:** `true`
 
 ```bash
@@ -69,8 +69,8 @@ LOG_TIMESTAMP=false
 **Controls whether colored output is used (when supported by runtime).**
 
 **Variable:** `LOG_COLOR`  
-**Values:** `true`, `false`  
-**Default:** Auto-detected based on runtime capabilities
+**Values:** `true`, `1`, `yes`, `on` / `false`, `0`, `no`, `off` (case-insensitive)  
+**Default:** Colored only when stdout is a terminal. `NO_COLOR` and `FORCE_COLOR` are honored.
 
 ```bash
 # Force colored output
@@ -170,12 +170,31 @@ env:
 
 ## Priority Order
 
-Environment variables are loaded in this priority order (highest to lowest):
+Highest to lowest:
 
-1. **Environment variables** (e.g., `LOG_LEVEL`)
+1. **Environment variables** (e.g. `LOG_LEVEL`)
 2. **Manual configuration** passed to `createLogger(config)`
 3. **Environment-based defaults** from `NODE_ENV`, `NEXT_PUBLIC_APP_ENV`, `ENVIRONMENT`
 4. **Library defaults**
+
+Environment variables sit at the top deliberately, so an operator can change
+logging on a running service without a deploy. A library that must pin its own
+logging regardless of the host application's environment opts out:
+
+```typescript
+const logger = createLogger({ level: LogLevel.WARN, ignoreEnvironment: true });
+```
+
+**Config files are not in this chain.** `loadConfigFromFile()` is exported and
+usable directly, but `createLogger()` is synchronous and cannot await it. See
+[#58](https://github.com/llbbl/logan-logger-ts/issues/58).
+
+### Unrecognized values
+
+A variable that does not parse is **ignored with a warning**, falling through to
+the next source rather than resolving to a default. `LOG_LEVEL=verbose` does not
+silently become `info`, and `LOG_TIMESTAMP=maybe` does not silently turn
+timestamps off. Each distinct problem warns once per process.
 
 ## Runtime Considerations
 
@@ -183,6 +202,11 @@ Environment variables are loaded in this priority order (highest to lowest):
 All environment variables are supported through `process.env`.
 
 ### Browser
+`LOG_*` variables are **build-time** in browsers, not runtime — there is no
+`process.env` to read. Your bundler must inline them, and by default bundlers
+only inline their own prefixed names, so an unprefixed `LOG_LEVEL` will not be
+picked up unless you map it explicitly (for example via `define` in Vite).
+
 Environment variables must be made available at build time:
 - **Vite**: Variables prefixed with `VITE_`
 - **Next.js**: Variables prefixed with `NEXT_PUBLIC_`

--- a/docs/import-compatibility.md
+++ b/docs/import-compatibility.md
@@ -28,7 +28,8 @@ does not need to guess.
 ## Related
 
 - [#42](https://github.com/llbbl/logan-logger-ts/issues/42) — JSR distribution
-  silently falls back to console logging because the bare `winston` import is
-  rewritten to `./winston` during publish. The npm distribution is unaffected.
+  silently fell back to console logging because the bare `winston` import was
+  rewritten to `./winston` during publish. **Resolved in 2.0**: Winston is gone,
+  so there is no bare import left to rewrite.
 - [#43](https://github.com/llbbl/logan-logger-ts/issues/43) — npm dual-publish
   layout previously broke named imports under tsx / CJS interop.

--- a/docs/jsr-winston-import-bug.md
+++ b/docs/jsr-winston-import-bug.md
@@ -1,5 +1,15 @@
 # JSR Winston Import Bug
 
+> **Resolved in 2.0.0 — kept as a record of the failure mode.**
+>
+> Winston was removed entirely in 2.0.0 ([#47](https://github.com/llbbl/logan-logger-ts/issues/47)).
+> There is no bare `winston` import left for JSR's publish pipeline to rewrite, and the
+> `const winstonModule = 'winston'` indirection described below has been deleted along
+> with it. `src/runtime/node.ts` now contains no dynamic imports at all — `deno publish
+> --dry-run` reports zero `unanalyzable-dynamic-import` warnings against it.
+>
+> If you are on 1.x, everything below still applies.
+
 ## Symptom
 
 Consumers installing `@logan/logger` from JSR (e.g., `pnpm add jsr:@logan/logger`)

--- a/docs/migration-2.0.md
+++ b/docs/migration-2.0.md
@@ -1,0 +1,108 @@
+# Migrating to logan-logger 2.0
+
+Two behaviour changes and one dependency removal. Most applications need no code
+change at all; the ones that do are listed under **What breaks**.
+
+## What changed
+
+| | 1.x | 2.0 |
+|---|---|---|
+| Node.js backend | Winston, if installed; console otherwise | Own console + file transports |
+| `winston` dependency | optional peer | **removed** |
+| File logging | implicit under `NODE_ENV=production` | **opt-in** via `transports` |
+| `config.transports` | declared, ignored | honored |
+| `config.timestamp` / `config.colorize` | declared, ignored | honored (text form only) |
+| Repeated object references | `"[Circular]"` | serialized in full |
+| Child loggers | new Winston instance + file handles each | share the parent's transports |
+
+## What breaks
+
+### 1. Your Node.js log format changes
+
+If you had `winston` installed, `NodeLogger` used Winston's formatters. It now
+uses the library's own.
+
+```
+# 1.x, with winston, development
+14:32:07 [info]: User logged in {"userId":123}
+
+# 1.x, with winston, production
+{ "level": "info", "message": "User logged in", "userId": 123, "timestamp": "..." }
+
+# 2.0, text (default)
+[2026-08-22T14:32:07.891Z] INFO: User logged in {"userId":123}
+
+# 2.0, format: 'json'
+{"timestamp":"2026-08-22T14:32:07.891Z","level":"info","message":"User logged in","runtime":"node","metadata":{"userId":123}}
+```
+
+Note that metadata is now nested under a `metadata` key rather than spread across
+the top level of the record. **Check any log-shipping pipeline, grep-based alert,
+or dashboard query that parses these lines.**
+
+If you did *not* have `winston` installed, you were already on the console
+fallback and the text form is unchanged apart from `colorize` now being honored.
+
+### 2. File logging must be asked for
+
+1.x wrote `logs/error.log` and `logs/combined.log` whenever `NODE_ENV=production`,
+whether you wanted it or not. That failed in read-only containers and was the
+cause of [#44](https://github.com/llbbl/logan-logger-ts/issues/44).
+
+```typescript
+// 2.0 — restore the 1.x production behaviour explicitly
+import { LogLevel, NodeLogger } from 'logan-logger/node';
+
+const logger = new NodeLogger({
+  transports: [
+    { type: 'console', options: {} },
+    { type: 'file', level: LogLevel.ERROR, options: { filename: 'logs/error.log', maxsize: 5_242_880, maxFiles: 5 } },
+    { type: 'file', options: { filename: 'logs/combined.log', maxsize: 5_242_880, maxFiles: 10 } },
+  ],
+});
+```
+
+The `file` transport is registered by `logan-logger/node` and `logan-logger/bun`.
+Configure one from the main `logan-logger` entry point and you get a warning
+naming the entry point to import instead — that separation is what keeps
+`node:fs` out of browser bundles.
+
+### 3. Repeated references now serialize in full
+
+```typescript
+const user = { id: 7, name: 'jo' };
+logger.info('request', { actor: user, owner: user });
+
+// 1.x: {"actor":{"id":7,"name":"jo"},"owner":"[Circular]"}
+// 2.0: {"actor":{"id":7,"name":"jo"},"owner":{"id":7,"name":"jo"}}
+```
+
+`"[Circular]"` is now reserved for genuine cycles — a value that is its own
+ancestor. This is strictly more data than before, so it is unlikely to break a
+parser, but log volume can rise for payloads with heavy sharing.
+
+Traversal is also depth-limited at 100 levels, emitting `"[MaxDepth]"` rather
+than overflowing the stack. Override with
+`safeStringify(value, space, { maxDepth })`.
+
+### 4. `colorize` actually colorizes
+
+`config.colorize` was ignored by the shared formatter in 1.x. It now applies ANSI
+color to the level token in the text form — but only when stdout is a TTY, and
+never in the JSON form. `NO_COLOR` and `FORCE_COLOR` are honored.
+
+## What to remove
+
+```bash
+pnpm remove winston      # no longer a peer dependency
+```
+
+Drop `winston` from any bundler `external` / `externals` list. If you were
+working around [#42](https://github.com/llbbl/logan-logger-ts/issues/42) on JSR,
+that workaround can go too.
+
+## What is unchanged
+
+`createLogger`, `createLoggerForEnvironment`, `ILogger`, every log method, lazy
+message functions, `logger.child()`, `createMorganStream`, the browser and Deno
+adapters, and all environment variables.

--- a/docs/migration-2.0.md
+++ b/docs/migration-2.0.md
@@ -14,6 +14,8 @@ change at all; the ones that do are listed under **What breaks**.
 | `config.timestamp` / `config.colorize` | declared, ignored | honored (text form only) |
 | Repeated object references | `"[Circular]"` | serialized in full |
 | Child loggers | new Winston instance + file handles each | share the parent's transports |
+| `LOG_LEVEL` and friends | parsed, never applied | applied, highest precedence |
+| `config.metadata` | declared, never emitted | on every record |
 
 ## What breaks
 
@@ -85,7 +87,51 @@ Traversal is also depth-limited at 100 levels, emitting `"[MaxDepth]"` rather
 than overflowing the stack. Override with
 `safeStringify(value, space, { maxDepth })`.
 
-### 4. `colorize` actually colorizes
+### 4. Environment variables start taking effect
+
+`LOG_LEVEL`, `LOG_FORMAT`, `LOG_TIMESTAMP` and `LOG_COLOR` were parsed by
+`loadConfigFromEnvironment()` in 1.x, but nothing ever called it — a logger built
+by `createLogger()` never saw them. They are now wired in at the top of the
+precedence chain.
+
+**If any of these variables is already set in your environment, your logging
+changes on upgrade** even though your code did not. A process running with
+`LOG_LEVEL=debug` set — perhaps years ago, for a different tool — starts emitting
+debug output.
+
+Two other things changed with the wiring:
+
+- **Boolean parsing is no longer strict.** 1.x resolved any value other than the
+  literal `"true"` to `false`, so `LOG_TIMESTAMP=1` meant *off*. 2.0 accepts
+  `true/1/yes/on` and `false/0/no/off`, case-insensitively.
+- **Unparseable values are ignored with a warning** rather than silently
+  resolving to a default. `LOG_LEVEL=verbose` no longer becomes `info`.
+
+To pin your logging against the host environment:
+
+```typescript
+const logger = createLogger({ level: LogLevel.WARN, ignoreEnvironment: true });
+```
+
+Config files are still not in the precedence chain — `loadConfigFromFile()` is
+async and `createLogger()` is not. That is [#58](https://github.com/llbbl/logan-logger-ts/issues/58).
+
+### 5. `config.metadata` is now emitted
+
+```typescript
+const logger = createLogger({ metadata: { service: 'api' } });
+logger.info('started');
+
+// 1.x: [ts] INFO: started
+// 2.0: [ts] INFO: started {"service":"api"}
+```
+
+`LoggerConfig.metadata` was documented as "default metadata to include with all
+log messages", carefully merged across configuration sources, and never read by
+the logger. It now seeds every record and is inherited by child loggers.
+Call-site metadata still wins on key collisions.
+
+### 6. `colorize` actually colorizes
 
 `config.colorize` was ignored by the shared formatter in 1.x. It now applies ANSI
 color to the level token in the text form — but only when stdout is a TTY, and
@@ -96,6 +142,9 @@ never in the JSON form. `NO_COLOR` and `FORCE_COLOR` are honored.
 ```bash
 pnpm remove winston      # no longer a peer dependency
 ```
+
+Also check your deployment environment for stale `LOG_*` variables, which now
+have an effect for the first time.
 
 Drop `winston` from any bundler `external` / `externals` list. If you were
 working around [#42](https://github.com/llbbl/logan-logger-ts/issues/42) on JSR,

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -16,7 +16,7 @@ Logan Logger (`logan-logger`) is a universal TypeScript logging library designed
 
 ### 2. Minimal Dependencies
 - Zero dependencies for core functionality
-- Optional runtime-specific dependencies (e.g., Winston for Node.js)
+- No runtime dependencies at all, on any runtime
 - Dependency injection pattern for extensibility
 
 ### 3. Performance First
@@ -87,9 +87,9 @@ interface RuntimeCapabilities {
 ## Runtime-Specific Implementations
 
 ### Node.js Logger
-- **Primary**: Winston-based implementation with file rotation, transports
-- **Fallback**: Console-based logger with formatting
-- **Features**: File system logging, process info, color support, streams
+- **Primary**: Own console and file transports built on `node:fs`
+- **Features**: Size-based file rotation, opt-in file logging, custom transports,
+  process info, color support, streams
 
 ### Deno Logger
 - **Primary**: Native Deno logging APIs
@@ -315,7 +315,7 @@ logan-logger-ts/
 
 | Runtime | Version | Status | Implementation | Dependencies |
 |---------|---------|--------|----------------|--------------|
-| Node.js | 20+     | ✅ Full | Winston wrapper | winston (optional) |
+| Node.js | 20+     | ✅ Full | Console + File transports | None |
 | Deno | 1.0+    | 🟡 Planned | Native APIs | None |
 | Bun | 0.5+    | 🟡 Planned | Native APIs | None |
 | Browser | Modern  | 🟡 Planned | Console API | None |

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -3,7 +3,7 @@
 ## Core Development Tasks
 
 ### Phase 1: Research & Planning
-- [x] Research Winston compatibility across JavaScript runtimes (Node.js, Deno, Bun, WASM)
+- [x] Research Winston compatibility across JavaScript runtimes (Node.js, Deno, Bun, WASM) — dropped in 2.0, see #47
 - [x] Investigate alternative logging libraries for runtime-specific implementations
 - [x] Define common logging interface/API that works across all runtimes
 - [x] Document runtime-specific constraints and capabilities
@@ -15,7 +15,7 @@
 - [x] Define common log levels and formatting standards
 
 ### Phase 3: Runtime-Specific Implementations
-- [x] Implement Node.js logger (Winston-based if compatible)
+- [x] Implement Node.js logger (own console + file transports as of 2.0)
 - [x] Implement Deno logger (using browser adapter for now)
 - [x] Implement Bun logger (using Node.js adapter)
 - [x] Implement WASM/browser logger
@@ -71,7 +71,7 @@
 ### Compatibility Matrix
 | Runtime | Status | Primary Implementation | Fallback |
 |---------|--------|----------------------|----------|
-| Node.js | ✅ | Winston | Console |
+| Node.js | ✅ | Console + File transports | Console |
 | Deno    | ✅ | Browser adapter | Console |
 | Bun     | ✅ | Node.js adapter | Console |
 | Browser | ✅ | Console API | Console |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -52,10 +52,12 @@ npm install -D ignore-loader
 ```
 Module not found: Can't resolve 'fs'
 Import trace for requested module:
-./node_modules/winston/dist/winston/transports/file.js
+./node_modules/logan-logger/dist/chunks/file-transport-*.mjs
 ```
 
-**Cause:** Server-side code (winston) being imported in browser context.
+**Cause:** Node-only code (the file transport) being imported in a browser context.
+Note that `logan-logger` and `logan-logger/browser` never reach it; only
+`logan-logger/node` and `logan-logger/bun` do.
 
 **Solutions:**
 
@@ -63,7 +65,7 @@ Import trace for requested module:
    ```typescript
    // ❌ Don't import server logger in client components
    'use client';
-   import serverLogger from '@/utils/serverLogger'; // Contains winston
+   import serverLogger from '@/utils/serverLogger'; // Imports logan-logger/node
 
    // ✅ Use browser-safe logger in client components
    'use client';
@@ -224,9 +226,9 @@ const logger = createLogger({
 
 #### Browser Issues
 
-**Error: "winston is not defined"**
+**Error: "Can't resolve 'node:fs'"**
 
-**Cause:** Server-specific logger used in browser.
+**Cause:** Server-specific entry point (`logan-logger/node`) used in a browser build.
 
 **Solution:**
 ```typescript
@@ -252,19 +254,17 @@ console.log('Current level:', logger.getLevel());
 
 #### Node.js Issues
 
-**Error: "winston.createLogger is not a function"**
+**Warning: "the 'file' transport is not registered"**
 
-**Install winston:**
-```bash
-npm install winston
-```
+**Cause:** A `{ type: 'file' }` transport was configured from the main entry
+point, which deliberately does not pull in `node:fs`.
 
-**Or use generic logger:**
+**Solution — import from the Node entry point:**
 ```typescript
-// ✅ No winston dependency
+// ❌ file transport unavailable here
 import { createLogger } from 'logan-logger';
 
-// ✅ Explicit winston usage
+// ✅ registers the file transport
 import { createLogger } from 'logan-logger/node';
 ```
 

--- a/docs/webpack-bundler-compatibility.md
+++ b/docs/webpack-bundler-compatibility.md
@@ -171,8 +171,8 @@ export default {
     commonjs(),
   ],
   external: [
-    // Externalize winston for Node.js builds
-    'winston',
+    // Node built-ins are resolved by the runtime, never bundled
+    /^node:/,
   ],
 };
 ```
@@ -208,7 +208,7 @@ require('esbuild').build({
   outfile: 'dist/bundle.js',
   format: 'esm',
   // Logan Logger works with default settings
-  external: ['winston'], // Only for Node.js builds
+  external: [/^node:/], // Node built-ins, only reached by Node.js builds
 });
 ```
 
@@ -263,8 +263,9 @@ module.exports = {
     },
   },
   externals: {
-    // Don't bundle winston
-    winston: 'winston',
+    // Node built-ins are resolved by the runtime
+    'node:fs': 'commonjs node:fs',
+    'node:path': 'commonjs node:path',
   },
 };
 ```
@@ -324,7 +325,7 @@ import { createLogger, LogLevel } from 'logan-logger';
 import * as LoganLogger from 'logan-logger';
 ```
 
-### Issue: Winston errors in browser
+### Issue: `node:fs` cannot be resolved in a browser build
 
 **Cause**: Server-side logger being used in browser context.
 

--- a/package.json
+++ b/package.json
@@ -105,7 +105,8 @@
     "deno",
     "bun",
     "browser",
-    "winston"
+    "zero-dependencies",
+    "structured-logging"
   ],
   "author": "Logan Lindquist Land",
   "license": "MIT",
@@ -119,14 +120,6 @@
     "vite": "^8.2.2",
     "vite-plugin-dts": "^4.5.4",
     "vitest": "^4.1.0"
-  },
-  "peerDependencies": {
-    "winston": "^3.8.0"
-  },
-  "peerDependenciesMeta": {
-    "winston": {
-      "optional": true
-    }
   },
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,10 +10,6 @@ overrides:
 importers:
 
   .:
-    dependencies:
-      winston:
-        specifier: ^3.8.0
-        version: 3.17.0
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.18.2
@@ -137,13 +133,6 @@ packages:
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
-
-  '@colors/colors@1.6.0':
-    resolution: {integrity: sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==}
-    engines: {node: '>=0.1.90'}
-
-  '@dabh/diagnostics@2.0.3':
-    resolution: {integrity: sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==}
 
   '@esbuild/aix-ppc64@0.27.1':
     resolution: {integrity: sha512-HHB50pdsBX6k47S4u5g/CaLjqS3qwaOVE5ILsq64jyzgMhLuCuZ8rGzM9yhsAjfjkbgUPMzZEPa7DAp7yz6vuA==}
@@ -611,9 +600,6 @@ packages:
   '@types/node@25.5.0':
     resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
 
-  '@types/triple-beam@1.3.5':
-    resolution: {integrity: sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==}
-
   '@vitest/expect@4.1.0':
     resolution: {integrity: sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==}
 
@@ -733,9 +719,6 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
-  async@3.2.6:
-    resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
-
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -773,27 +756,12 @@ packages:
   cliui@7.0.4:
     resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
 
-  color-convert@1.9.3:
-    resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
-
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
 
-  color-name@1.1.3:
-    resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
-
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
-
-  color-string@1.9.1:
-    resolution: {integrity: sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==}
-
-  color@3.2.1:
-    resolution: {integrity: sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==}
-
-  colorspace@1.1.4:
-    resolution: {integrity: sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==}
 
   commander@10.0.1:
     resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
@@ -832,9 +800,6 @@ packages:
 
   emojilib@2.4.0:
     resolution: {integrity: sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==}
-
-  enabled@2.0.0:
-    resolution: {integrity: sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==}
 
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
@@ -881,9 +846,6 @@ packages:
       picomatch:
         optional: true
 
-  fecha@4.2.3:
-    resolution: {integrity: sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==}
-
   fflate@0.8.2:
     resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
 
@@ -892,9 +854,6 @@ packages:
 
   flatted@3.4.0:
     resolution: {integrity: sha512-kC6Bb+ooptOIvWj5B63EQWkF0FEnNjV2ZNkLMLZRDDduIiWeFF4iKnslwhiWxjAdbg4NzTNo6h0qLuvFrcx+Sw==}
-
-  fn.name@1.1.0:
-    resolution: {integrity: sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==}
 
   fs-extra@11.3.2:
     resolution: {integrity: sha512-Xr9F6z6up6Ws+NjzMCZc6WXg2YFRlrLP9NQDO3VQrWrfiojdhS56TzueT88ze0uBdCTwEIhQ3ptnmKeWGFAe0A==}
@@ -934,22 +893,12 @@ packages:
     resolution: {integrity: sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==}
     engines: {node: '>=8'}
 
-  inherits@2.0.4:
-    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
-
-  is-arrayish@0.3.4:
-    resolution: {integrity: sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==}
-
   is-core-module@2.16.1:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
     engines: {node: '>= 0.4'}
 
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
-    engines: {node: '>=8'}
-
-  is-stream@2.0.1:
-    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
 
   jju@1.4.0:
@@ -963,9 +912,6 @@ packages:
 
   kolorist@1.8.0:
     resolution: {integrity: sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==}
-
-  kuler@2.0.0:
-    resolution: {integrity: sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==}
 
   lightningcss-android-arm64@1.33.0:
     resolution: {integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==}
@@ -1048,10 +994,6 @@ packages:
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
-  logform@2.7.0:
-    resolution: {integrity: sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==}
-    engines: {node: '>= 12.0.0'}
-
   lru-cache@11.5.2:
     resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
     engines: {node: 20 || >=22}
@@ -1121,9 +1063,6 @@ packages:
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
-  one-time@1.0.0:
-    resolution: {integrity: sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==}
-
   package-manager-detector@1.8.0:
     resolution: {integrity: sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==}
 
@@ -1178,10 +1117,6 @@ packages:
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
 
-  readable-stream@3.6.2:
-    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
-    engines: {node: '>= 6'}
-
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
@@ -1209,13 +1144,6 @@ packages:
     resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
     engines: {node: '>=6'}
 
-  safe-buffer@5.2.1:
-    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
-
-  safe-stable-stringify@2.5.0:
-    resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
-    engines: {node: '>=10'}
-
   semver@7.5.4:
     resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==}
     engines: {node: '>=10'}
@@ -1223,9 +1151,6 @@ packages:
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
-
-  simple-swizzle@0.2.4:
-    resolution: {integrity: sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==}
 
   sirv@3.0.2:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
@@ -1246,9 +1171,6 @@ packages:
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
-  stack-trace@0.0.10:
-    resolution: {integrity: sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==}
-
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
@@ -1262,9 +1184,6 @@ packages:
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
-
-  string_decoder@1.3.0:
-    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -1289,9 +1208,6 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
-
-  text-hex@1.0.0:
-    resolution: {integrity: sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==}
 
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
@@ -1327,10 +1243,6 @@ packages:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
 
-  triple-beam@1.4.1:
-    resolution: {integrity: sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==}
-    engines: {node: '>= 14.0.0'}
-
   typescript@5.6.1-rc:
     resolution: {integrity: sha512-E3b2+1zEFu84jB0YQi9BORDjz9+jGbwwy1Zi3G0LUNw7a7cePUrHMRNy8aPh53nXpkFGVHSxIZo5vKTfYaFiBQ==}
     engines: {node: '>=14.17'}
@@ -1362,9 +1274,6 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
-
-  util-deprecate@1.0.2:
-    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   validate-npm-package-name@5.0.1:
     resolution: {integrity: sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==}
@@ -1465,14 +1374,6 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
-  winston-transport@4.9.0:
-    resolution: {integrity: sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==}
-    engines: {node: '>= 12.0.0'}
-
-  winston@3.17.0:
-    resolution: {integrity: sha512-DLiFIXYC5fMPxaRg832S6F5mJYvePtmO5G9v9IgUFPhXm9/GkXarH/TUrBAVzhTCzAj9anE/+GjrgXp/54nOgw==}
-    engines: {node: '>= 12.0.0'}
-
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
@@ -1569,14 +1470,6 @@ snapshots:
 
   '@colors/colors@1.5.0':
     optional: true
-
-  '@colors/colors@1.6.0': {}
-
-  '@dabh/diagnostics@2.0.3':
-    dependencies:
-      colorspace: 1.1.4
-      enabled: 2.0.0
-      kuler: 2.0.0
 
   '@esbuild/aix-ppc64@0.27.1':
     optional: true
@@ -1885,8 +1778,6 @@ snapshots:
     dependencies:
       undici-types: 7.18.2
 
-  '@types/triple-beam@1.3.5': {}
-
   '@vitest/expect@4.1.0':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -2030,8 +1921,6 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
-  async@3.2.6: {}
-
   balanced-match@1.0.2: {}
 
   brace-expansion@2.0.2:
@@ -2072,32 +1961,11 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
 
-  color-convert@1.9.3:
-    dependencies:
-      color-name: 1.1.3
-
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
 
-  color-name@1.1.3: {}
-
   color-name@1.1.4: {}
-
-  color-string@1.9.1:
-    dependencies:
-      color-name: 1.1.4
-      simple-swizzle: 0.2.4
-
-  color@3.2.1:
-    dependencies:
-      color-convert: 1.9.3
-      color-string: 1.9.1
-
-  colorspace@1.1.4:
-    dependencies:
-      color: 3.2.1
-      text-hex: 1.0.0
 
   commander@10.0.1: {}
 
@@ -2120,8 +1988,6 @@ snapshots:
   emoji-regex@8.0.0: {}
 
   emojilib@2.4.0: {}
-
-  enabled@2.0.0: {}
 
   entities@4.5.0: {}
 
@@ -2181,15 +2047,11 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.5
 
-  fecha@4.2.3: {}
-
   fflate@0.8.2: {}
 
   fflate@0.8.3: {}
 
   flatted@3.4.0: {}
-
-  fn.name@1.1.0: {}
 
   fs-extra@11.3.2:
     dependencies:
@@ -2218,17 +2080,11 @@ snapshots:
 
   import-lazy@4.0.0: {}
 
-  inherits@2.0.4: {}
-
-  is-arrayish@0.3.4: {}
-
   is-core-module@2.16.1:
     dependencies:
       hasown: 2.0.2
 
   is-fullwidth-code-point@3.0.0: {}
-
-  is-stream@2.0.1: {}
 
   jju@1.4.0: {}
 
@@ -2241,8 +2097,6 @@ snapshots:
       graceful-fs: 4.2.11
 
   kolorist@1.8.0: {}
-
-  kuler@2.0.0: {}
 
   lightningcss-android-arm64@1.33.0:
     optional: true
@@ -2300,15 +2154,6 @@ snapshots:
       quansync: 0.2.11
 
   lodash@4.17.21: {}
-
-  logform@2.7.0:
-    dependencies:
-      '@colors/colors': 1.6.0
-      '@types/triple-beam': 1.3.5
-      fecha: 4.2.3
-      ms: 2.1.3
-      safe-stable-stringify: 2.5.0
-      triple-beam: 1.4.1
 
   lru-cache@11.5.2: {}
 
@@ -2379,10 +2224,6 @@ snapshots:
 
   obug@2.1.1: {}
 
-  one-time@1.0.0:
-    dependencies:
-      fn.name: 1.1.0
-
   package-manager-detector@1.8.0: {}
 
   parse5-htmlparser2-tree-adapter@6.0.1:
@@ -2433,12 +2274,6 @@ snapshots:
   punycode@2.3.1: {}
 
   quansync@0.2.11: {}
-
-  readable-stream@3.6.2:
-    dependencies:
-      inherits: 2.0.4
-      string_decoder: 1.3.0
-      util-deprecate: 1.0.2
 
   require-directory@2.1.1: {}
 
@@ -2504,19 +2339,11 @@ snapshots:
     dependencies:
       mri: 1.2.0
 
-  safe-buffer@5.2.1: {}
-
-  safe-stable-stringify@2.5.0: {}
-
   semver@7.5.4:
     dependencies:
       lru-cache: 6.0.0
 
   siginfo@2.0.0: {}
-
-  simple-swizzle@0.2.4:
-    dependencies:
-      is-arrayish: 0.3.4
 
   sirv@3.0.2:
     dependencies:
@@ -2534,8 +2361,6 @@ snapshots:
 
   sprintf-js@1.0.3: {}
 
-  stack-trace@0.0.10: {}
-
   stackback@0.0.2: {}
 
   std-env@4.0.0: {}
@@ -2547,10 +2372,6 @@ snapshots:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
-
-  string_decoder@1.3.0:
-    dependencies:
-      safe-buffer: 5.2.1
 
   strip-ansi@6.0.1:
     dependencies:
@@ -2572,8 +2393,6 @@ snapshots:
       supports-color: 7.2.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
-
-  text-hex@1.0.0: {}
 
   thenify-all@1.6.0:
     dependencies:
@@ -2603,8 +2422,6 @@ snapshots:
 
   totalist@3.0.1: {}
 
-  triple-beam@1.4.1: {}
-
   typescript@5.6.1-rc: {}
 
   typescript@5.8.2: {}
@@ -2622,8 +2439,6 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
-
-  util-deprecate@1.0.2: {}
 
   validate-npm-package-name@5.0.1: {}
 
@@ -2692,26 +2507,6 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
-
-  winston-transport@4.9.0:
-    dependencies:
-      logform: 2.7.0
-      readable-stream: 3.6.2
-      triple-beam: 1.4.1
-
-  winston@3.17.0:
-    dependencies:
-      '@colors/colors': 1.6.0
-      '@dabh/diagnostics': 2.0.3
-      async: 3.2.6
-      is-stream: 2.0.1
-      logform: 2.7.0
-      one-time: 1.0.0
-      readable-stream: 3.6.2
-      safe-stable-stringify: 2.5.0
-      stack-trace: 0.0.10
-      triple-beam: 1.4.1
-      winston-transport: 4.9.0
 
   wrap-ansi@7.0.0:
     dependencies:

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -13,25 +13,9 @@ export * from './utils/serialization.ts';
 import { type ILogger, type LoggerConfig, LogLevel } from './core/types.ts';
 // Browser-specific factory functions (avoid importing Node.js factory)
 import { BrowserLogger } from './runtime/browser.ts';
-import { detectRuntime } from './utils/runtime.ts';
-
-function getDefaultBrowserConfig(): LoggerConfig {
-  const runtime = detectRuntime();
-
-  return {
-    level: LogLevel.INFO,
-    format: 'text',
-    timestamp: true,
-    colorize: runtime.capabilities.colorSupport,
-    metadata: {},
-    transports: [
-      {
-        type: 'console',
-        options: {},
-      },
-    ],
-  };
-}
+// utils/config.ts is free of Node specifiers by design; the file-loading half
+// lives in utils/config-file.ts and is deliberately not imported here.
+import { loadConfigFromEnvironment, mergeConfigs } from './utils/config.ts';
 
 function getBrowserEnvironment(): string {
   // Check various environment variables
@@ -74,17 +58,12 @@ function getLogLevelForBrowserEnvironment(env: string): LogLevel {
  * Creates a BrowserLogger instance without importing Node.js dependencies.
  */
 export function createLogger(config: Partial<LoggerConfig> = {}): ILogger {
-  const defaultConfig = getDefaultBrowserConfig();
-  const mergedConfig = {
-    ...defaultConfig,
-    ...config,
-    metadata: {
-      ...defaultConfig.metadata,
-      ...config.metadata,
-    },
-  };
+  // Same precedence as the main factory: defaults < explicit config <
+  // environment. In a browser the LOG_* variables exist only if the bundler
+  // inlined them at build time, in which case this is a no-op.
+  const environment = config.ignoreEnvironment ? {} : loadConfigFromEnvironment();
 
-  return new BrowserLogger(mergedConfig);
+  return new BrowserLogger(mergeConfigs(config, environment));
 }
 
 /**

--- a/src/bun.ts
+++ b/src/bun.ts
@@ -2,9 +2,18 @@
 // Import this module when running in Bun environments
 
 export { createLogger, createLoggerForEnvironment } from './core/factory.ts';
+export {
+  ConsoleTransport,
+  createTransports,
+  registerTransport,
+  type Transport,
+  type TransportFactory,
+} from './core/transport.ts';
 
 // Re-export core functionality optimized for Bun
-export type { ILogger, LoggerConfig, LogLevel } from './core/types.ts';
+export type { ILogger, LoggerConfig, LogLevel, TransportConfig } from './core/types.ts';
+// Registers the 'file' transport for Bun, which implements node:fs.
+export { FileTransport, type FileTransportOptions } from './runtime/file-transport.ts';
 export { NodeLogger } from './runtime/node.ts';
 export * from './utils/config.ts';
 export * from './utils/formatting.ts';

--- a/src/bun.ts
+++ b/src/bun.ts
@@ -15,6 +15,7 @@ export type { ILogger, LoggerConfig, LogLevel, TransportConfig } from './core/ty
 // Registers the 'file' transport for Bun, which implements node:fs.
 export { FileTransport, type FileTransportOptions } from './runtime/file-transport.ts';
 export { NodeLogger } from './runtime/node.ts';
+export * from './utils/config-file.ts';
 export * from './utils/config.ts';
 export * from './utils/formatting.ts';
 // Bun-specific utilities

--- a/src/core/factory.ts
+++ b/src/core/factory.ts
@@ -1,6 +1,6 @@
 import { BrowserLogger } from '../runtime/browser.ts';
 import { NodeLogger } from '../runtime/node.ts';
-import { getDefaultConfig } from '../utils/config.ts';
+import { getDefaultConfig, shouldColorize } from '../utils/config.ts';
 import { detectRuntime } from '../utils/runtime.ts';
 import { type ILogger, type LoggerConfig, LogLevel } from './types.ts';
 
@@ -96,7 +96,7 @@ export function createLoggerForEnvironment(): ILogger {
 
   const config: Partial<LoggerConfig> = {
     level: getLogLevelForEnvironment(env),
-    colorize: env !== 'production',
+    colorize: env !== 'production' && shouldColorize(),
     timestamp: true,
     format: env === 'production' ? 'json' : 'text',
   };

--- a/src/core/factory.ts
+++ b/src/core/factory.ts
@@ -1,6 +1,11 @@
 import { BrowserLogger } from '../runtime/browser.ts';
 import { NodeLogger } from '../runtime/node.ts';
-import { getDefaultConfig, shouldColorize } from '../utils/config.ts';
+import {
+  loadConfigFromEnvironment,
+  mergeConfigs,
+  shouldColorize,
+  tryParseLogLevel,
+} from '../utils/config.ts';
 import { detectRuntime } from '../utils/runtime.ts';
 import { type ILogger, type LoggerConfig, LogLevel } from './types.ts';
 
@@ -52,16 +57,26 @@ export class LoggerFactory {
     return parent.child(metadata);
   }
 
+  /**
+   * Assemble the effective configuration.
+   *
+   * Precedence, lowest to highest:
+   *
+   *     library defaults  <  explicit config  <  environment variables
+   *
+   * Environment variables win so that an operator can change logging on a
+   * running service without a deploy. A consumer that must not be overridden
+   * that way sets `ignoreEnvironment: true`.
+   *
+   * The config-file link of the chain documented in `docs/environment-variables.md`
+   * is still missing: `loadConfigFromFile` is async and this path is not.
+   */
   private static mergeConfig(userConfig: Partial<LoggerConfig>): Partial<LoggerConfig> {
-    const defaultConfig = getDefaultConfig();
-    return {
-      ...defaultConfig,
-      ...userConfig,
-      metadata: {
-        ...defaultConfig.metadata,
-        ...userConfig.metadata,
-      },
-    };
+    const environment = userConfig.ignoreEnvironment ? {} : loadConfigFromEnvironment();
+
+    // mergeConfigs seeds itself with getDefaultConfig(), so defaults must not
+    // be passed again here.
+    return mergeConfigs(userConfig, environment);
   }
 }
 
@@ -140,24 +155,16 @@ function getLogLevelForEnvironment(env: string): LogLevel {
   }
 }
 
-// Type-safe log level conversion
+/**
+ * Convert a level string to a `LogLevel`, falling back to INFO.
+ *
+ * Delegates to the single parser in `utils/config.ts`; use `tryParseLogLevel`
+ * directly when an unrecognized value should be distinguishable from `info`.
+ * @param level - The value to convert
+ * @returns The matching level, or `LogLevel.INFO`
+ */
 export function stringToLogLevel(level: string): LogLevel {
-  switch (level.toLowerCase()) {
-    case 'debug':
-      return LogLevel.DEBUG;
-    case 'info':
-      return LogLevel.INFO;
-    case 'warn':
-    case 'warning':
-      return LogLevel.WARN;
-    case 'error':
-      return LogLevel.ERROR;
-    case 'silent':
-    case 'none':
-      return LogLevel.SILENT;
-    default:
-      return LogLevel.INFO;
-  }
+  return tryParseLogLevel(level) ?? LogLevel.INFO;
 }
 
 export function logLevelToString(level: LogLevel): string {

--- a/src/core/logger.ts
+++ b/src/core/logger.ts
@@ -19,6 +19,10 @@ export abstract class BaseLogger implements ILogger {
     this.config = config;
     this.level = config.level ?? LogLevel.INFO;
     this.runtime = detectRuntime().name;
+    // config.metadata is the documented "default metadata on every message".
+    // Seeding childMetadata is what makes that true, and it inherits through
+    // child() for free.
+    this.childMetadata = { ...config.metadata };
   }
 
   // biome-ignore lint/suspicious/noExplicitAny: Intentional - logger accepts arbitrary metadata (see ILogger interface)

--- a/src/core/transport.ts
+++ b/src/core/transport.ts
@@ -1,0 +1,199 @@
+import { type FormatOptions, formatLogEntry } from '../utils/formatting.ts';
+import { type LogEntry, type LoggerConfig, LogLevel, type TransportConfig } from './types.ts';
+
+/**
+ * A destination log entries are written to.
+ *
+ * Transports are constructed once per logger and shared with every child
+ * logger, so a transport that owns a resource (a file handle, a socket) must
+ * open exactly one of them however many children are created.
+ */
+export interface Transport {
+  /** Transport type, used in diagnostics. */
+  readonly type: string;
+  /** Minimum level this transport accepts. Undefined means "whatever the logger allows". */
+  readonly level?: LogLevel;
+  /** Write one entry. */
+  write(entry: LogEntry): void;
+  /** Release any resources held. Safe to call more than once. */
+  close?(): void;
+}
+
+/**
+ * The logger-level presentation settings a transport inherits unless its own
+ * options override them.
+ */
+export interface TransportContext {
+  format: 'json' | 'text' | 'custom';
+  timestamp: boolean;
+  colorize: boolean;
+}
+
+/** Builds a transport from its configuration entry. */
+export type TransportFactory = (config: TransportConfig, context: TransportContext) => Transport;
+
+const transportFactories = new Map<string, TransportFactory>();
+
+/**
+ * Register a factory for a transport type so it can be named in
+ * `LoggerConfig.transports`.
+ *
+ * Runtime-specific transports register themselves from their runtime entry
+ * point — the Node file transport is registered by `logan-logger/node`, which
+ * is what keeps `node:fs` out of the browser build.
+ *
+ * @param type - Value matched against `TransportConfig.type`
+ * @param factory - Builder invoked once per configured transport
+ */
+export function registerTransport(type: string, factory: TransportFactory): void {
+  transportFactories.set(type, factory);
+}
+
+/** Look up a registered transport factory. */
+export function getTransportFactory(type: string): TransportFactory | undefined {
+  return transportFactories.get(type);
+}
+
+/** Options accepted by {@link ConsoleTransport}. */
+export interface ConsoleTransportOptions extends FormatOptions {
+  /** Output shape. `'custom'` is treated as `'text'`. */
+  format?: 'json' | 'text' | 'custom';
+  /** Minimum level this transport accepts. */
+  level?: LogLevel;
+}
+
+/**
+ * Writes formatted entries to the runtime console, routing each level to the
+ * matching console method so devtools and journald keep their severity.
+ */
+export class ConsoleTransport implements Transport {
+  readonly type = 'console';
+  readonly level?: LogLevel;
+
+  private readonly format: 'json' | 'text';
+  private readonly formatOptions: FormatOptions;
+
+  constructor(options: ConsoleTransportOptions = {}) {
+    this.level = options.level;
+    this.format = options.format === 'json' ? 'json' : 'text';
+    this.formatOptions = {
+      timestamp: options.timestamp !== false,
+      colorize: options.colorize === true,
+    };
+  }
+
+  write(entry: LogEntry): void {
+    const line = formatLogEntry(entry, this.format, this.formatOptions);
+
+    switch (entry.level) {
+      case LogLevel.DEBUG:
+        console.debug(line);
+        break;
+      case LogLevel.WARN:
+        console.warn(line);
+        break;
+      case LogLevel.ERROR:
+        console.error(line);
+        break;
+      default:
+        console.info(line);
+        break;
+    }
+  }
+}
+
+registerTransport('console', (config, context) => {
+  const options = config.options ?? {};
+
+  return new ConsoleTransport({
+    format: options.format ?? context.format,
+    timestamp: options.timestamp ?? context.timestamp,
+    colorize: options.colorize ?? context.colorize,
+    level: config.level,
+  });
+});
+
+// `{ type: 'custom', options: { transport } }` accepts any object satisfying
+// the Transport interface, so callers can plug in their own destination
+// without waiting for a built-in.
+registerTransport('custom', (config) => {
+  const supplied = config.options?.transport as Transport | undefined;
+
+  if (!supplied || typeof supplied.write !== 'function') {
+    throw new Error(
+      "custom transport requires options.transport to be an object with a write(entry) method"
+    );
+  }
+
+  if (config.level === undefined) {
+    return supplied;
+  }
+
+  // Wrap rather than spread: a class instance loses its prototype methods when
+  // copied into an object literal.
+  return {
+    type: supplied.type ?? 'custom',
+    level: config.level,
+    write: (entry) => supplied.write(entry),
+    close: supplied.close ? () => supplied.close?.() : undefined,
+  };
+});
+
+/**
+ * Build the transports described by a logger configuration.
+ *
+ * Each transport is constructed behind its own guard so that one failing to
+ * initialize cannot take the others down with it.
+ *
+ * @param config - The logger configuration
+ * @returns The transports that were built successfully
+ */
+export function createTransports(config: Partial<LoggerConfig>): Transport[] {
+  const context: TransportContext = {
+    format: config.format ?? 'text',
+    timestamp: config.timestamp ?? true,
+    colorize: config.colorize ?? false,
+  };
+
+  // No transports configured at all means console only. File logging is
+  // opt-in; it is never implied by NODE_ENV.
+  if (config.transports === undefined) {
+    return [
+      new ConsoleTransport({
+        format: context.format,
+        timestamp: context.timestamp,
+        colorize: context.colorize,
+      }),
+    ];
+  }
+
+  const transports: Transport[] = [];
+
+  for (const entry of config.transports) {
+    const factory = getTransportFactory(entry.type);
+
+    if (!factory) {
+      console.warn(`[logan-logger] ${describeUnknownTransport(entry.type)}`);
+      continue;
+    }
+
+    try {
+      transports.push(factory(entry, context));
+    } catch (error) {
+      console.warn(`[logan-logger] transport '${entry.type}' failed to initialize:`, error);
+    }
+  }
+
+  return transports;
+}
+
+function describeUnknownTransport(type: string): string {
+  if (type === 'file') {
+    return "the 'file' transport is not registered; import from 'logan-logger/node' (or 'logan-logger/bun') rather than the main entry point to use file logging";
+  }
+  if (type === 'http') {
+    return "the 'http' transport is not built in; supply one with { type: 'custom', options: { transport } }";
+  }
+
+  return `unknown transport type '${type}'; skipping`;
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -68,6 +68,15 @@ export interface LoggerConfig {
   metadata: Record<string, any>;
   /** Transport configurations for log output */
   transports?: TransportConfig[];
+  /**
+   * Ignore `LOG_LEVEL`, `LOG_FORMAT`, `LOG_TIMESTAMP` and `LOG_COLOR`.
+   *
+   * Environment variables normally sit at the top of the precedence chain so an
+   * operator can raise verbosity on a running service without a deploy. A
+   * library that must pin its own logging regardless of the host application's
+   * environment sets this instead.
+   */
+  ignoreEnvironment?: boolean;
 }
 
 /**

--- a/src/deno.ts
+++ b/src/deno.ts
@@ -13,6 +13,7 @@ export {
 } from './core/transport.ts';
 export type { ILogger, LoggerConfig, LogLevel, TransportConfig } from './core/types.ts';
 export { BrowserLogger, ConsoleGroupLogger, PerformanceLogger } from './runtime/browser.ts';
+export * from './utils/config-file.ts';
 export * from './utils/config.ts';
 export * from './utils/formatting.ts';
 // Deno-specific utilities

--- a/src/deno.ts
+++ b/src/deno.ts
@@ -4,7 +4,14 @@
 export { createLogger, createLoggerForEnvironment } from './core/factory.ts';
 
 // Re-export core functionality optimized for Deno
-export type { ILogger, LoggerConfig, LogLevel } from './core/types.ts';
+export {
+  ConsoleTransport,
+  createTransports,
+  registerTransport,
+  type Transport,
+  type TransportFactory,
+} from './core/transport.ts';
+export type { ILogger, LoggerConfig, LogLevel, TransportConfig } from './core/types.ts';
 export { BrowserLogger, ConsoleGroupLogger, PerformanceLogger } from './runtime/browser.ts';
 export * from './utils/config.ts';
 export * from './utils/formatting.ts';

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@
 
 export * from './core/factory.ts';
 export * from './core/logger.ts';
+export * from './core/transport.ts';
 export * from './core/types.ts';
 
 // Runtime-specific exports

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export * from './core/types.ts';
 
 // Runtime-specific exports
 export { BrowserLogger, ConsoleGroupLogger, PerformanceLogger } from './runtime/browser.ts';
+export * from './utils/config-file.ts';
 export * from './utils/config.ts';
 export * from './utils/formatting.ts';
 // Utilities

--- a/src/node.ts
+++ b/src/node.ts
@@ -2,7 +2,17 @@
 // Import this module only in Node.js environments
 
 export { createLogger, createLoggerForEnvironment } from './core/factory.ts';
+export {
+  ConsoleTransport,
+  createTransports,
+  registerTransport,
+  type Transport,
+  type TransportFactory,
+} from './core/transport.ts';
 
 // Re-export core types that are needed when using NodeLogger
-export type { ILogger, LoggerConfig, LogLevel } from './core/types.ts';
+export type { ILogger, LoggerConfig, LogLevel, TransportConfig } from './core/types.ts';
+// Importing this module registers the 'file' transport, which is why file
+// logging is available from this entry point and not from the main one.
+export { FileTransport, type FileTransportOptions } from './runtime/file-transport.ts';
 export { createMorganStream, NodeLogger } from './runtime/node.ts';

--- a/src/runtime/file-transport.ts
+++ b/src/runtime/file-transport.ts
@@ -1,0 +1,226 @@
+import {
+  closeSync,
+  existsSync,
+  fstatSync,
+  mkdirSync,
+  openSync,
+  renameSync,
+  unlinkSync,
+  writeSync,
+} from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { registerTransport, type Transport } from '../core/transport.ts';
+import type { LogEntry, LogLevel } from '../core/types.ts';
+import { formatLogEntry } from '../utils/formatting.ts';
+
+/** Default rotation threshold: 5 MiB. */
+const DEFAULT_MAX_SIZE = 5 * 1024 * 1024;
+
+/** Default number of rotated archives kept alongside the active file. */
+const DEFAULT_MAX_FILES = 5;
+
+/** Options accepted by {@link FileTransport}. */
+export interface FileTransportOptions {
+  /** Path to the active log file. Relative paths resolve against `process.cwd()`. */
+  filename: string;
+  /** Rotate once the active file reaches this many bytes. `0` disables rotation. */
+  maxsize?: number;
+  /** How many rotated archives to keep (`name.log.1` … `name.log.N`). */
+  maxFiles?: number;
+  /**
+   * Output shape written to the file. Defaults to `'json'` — files are read by
+   * machines, so the structured envelope wins even when the logger's own
+   * format is `'text'`. Set this explicitly to write human-readable lines.
+   */
+  format?: 'json' | 'text' | 'custom';
+  /** Include the timestamp in the text form. Defaults to `true`. */
+  timestamp?: boolean;
+  /** Minimum level this transport accepts. */
+  level?: LogLevel;
+}
+
+/**
+ * Appends log entries to a file, rotating by size.
+ *
+ * Design notes, all of which are deliberate:
+ *
+ * - **The directory and file handle are created lazily, on first write.** A
+ *   logger that is constructed but never writes to a file touches the disk
+ *   zero times, which is what makes file logging safe to configure in a
+ *   read-only container.
+ * - **Writes are synchronous `writeSync` calls against a held file
+ *   descriptor.** That costs one syscall per line, and in exchange nothing
+ *   sits in a userland buffer waiting to be lost when the process exits.
+ * - **Failures warn once and never throw.** A logging destination going away
+ *   must not take the application with it, and it must not spam the console
+ *   on every subsequent line either.
+ */
+export class FileTransport implements Transport {
+  readonly type = 'file';
+  readonly level?: LogLevel;
+
+  private readonly path: string;
+  private readonly maxsize: number;
+  private readonly maxFiles: number;
+  private readonly format: 'json' | 'text';
+  private readonly timestamp: boolean;
+
+  private fd?: number;
+  private size = 0;
+  private warned = false;
+
+  constructor(options: FileTransportOptions) {
+    if (!options?.filename) {
+      throw new Error('file transport requires options.filename');
+    }
+
+    this.path = resolve(options.filename);
+    this.maxsize = options.maxsize ?? DEFAULT_MAX_SIZE;
+    this.maxFiles = options.maxFiles ?? DEFAULT_MAX_FILES;
+    this.format = options.format === 'text' ? 'text' : 'json';
+    this.timestamp = options.timestamp !== false;
+    this.level = options.level;
+  }
+
+  /** Absolute path of the active log file. */
+  get filename(): string {
+    return this.path;
+  }
+
+  write(entry: LogEntry): void {
+    const line = `${formatLogEntry(entry, this.format, {
+      timestamp: this.timestamp,
+      colorize: false,
+    })}\n`;
+
+    try {
+      this.open();
+
+      if (this.maxsize > 0 && this.size >= this.maxsize) {
+        this.rotate();
+        this.open();
+      }
+
+      this.size += writeSync(this.fd as number, line);
+    } catch (error) {
+      this.warnOnce(error);
+    }
+  }
+
+  close(): void {
+    if (this.fd === undefined) {
+      return;
+    }
+
+    try {
+      closeSync(this.fd);
+    } finally {
+      this.fd = undefined;
+    }
+  }
+
+  private open(): void {
+    if (this.fd !== undefined) {
+      return;
+    }
+
+    const directory = dirname(this.path);
+
+    try {
+      mkdirSync(directory, { recursive: true });
+    } catch (error) {
+      throw describeFsError('create log directory', directory, error);
+    }
+
+    try {
+      this.fd = openSync(this.path, 'a');
+    } catch (error) {
+      throw describeFsError('open log file', this.path, error);
+    }
+
+    this.size = fstatSync(this.fd).size;
+  }
+
+  /**
+   * Shift the archives along by one and start a fresh active file.
+   * `name.log` becomes `name.log.1`, `name.log.1` becomes `name.log.2`, and
+   * whatever was at `name.log.<maxFiles>` is dropped.
+   */
+  private rotate(): void {
+    this.close();
+
+    if (this.maxFiles <= 0) {
+      // No archives requested: drop the old contents outright.
+      if (existsSync(this.path)) {
+        unlinkSync(this.path);
+      }
+      this.size = 0;
+      return;
+    }
+
+    const oldest = `${this.path}.${this.maxFiles}`;
+    if (existsSync(oldest)) {
+      unlinkSync(oldest);
+    }
+
+    for (let index = this.maxFiles - 1; index >= 1; index--) {
+      const from = `${this.path}.${index}`;
+      if (existsSync(from)) {
+        renameSync(from, `${this.path}.${index + 1}`);
+      }
+    }
+
+    if (existsSync(this.path)) {
+      renameSync(this.path, `${this.path}.1`);
+    }
+
+    this.size = 0;
+  }
+
+  private warnOnce(error: unknown): void {
+    this.close();
+
+    if (this.warned) {
+      return;
+    }
+
+    this.warned = true;
+    console.warn(
+      `[logan-logger] file transport for '${this.path}' failed and will keep retrying quietly:`,
+      error instanceof Error ? error.message : error
+    );
+  }
+}
+
+/**
+ * Produce an error that names the resolved path and the underlying syscall,
+ * so a permissions problem never surfaces as something unrelated.
+ */
+function describeFsError(action: string, target: string, error: unknown): Error {
+  const cause = error as NodeJS.ErrnoException;
+  const code = cause?.code ? ` [${cause.code}]` : '';
+  const syscall = cause?.syscall ? ` during ${cause.syscall}` : '';
+
+  const failure = new Error(
+    `could not ${action} '${target}'${code}${syscall}: ${cause?.message ?? error}`
+  );
+  // Assigned rather than passed as ErrorOptions: the build targets es2020.
+  (failure as Error & { cause?: unknown }).cause = error;
+
+  return failure;
+}
+
+registerTransport('file', (config, context) => {
+  const options = config.options ?? {};
+
+  return new FileTransport({
+    filename: options.filename,
+    maxsize: options.maxsize,
+    maxFiles: options.maxFiles,
+    // Deliberately not inherited from context.format: a file defaults to the
+    // structured envelope whatever the console is doing.
+    format: options.format,
+    timestamp: options.timestamp ?? context.timestamp,
+    level: config.level,
+  });
+});

--- a/src/runtime/node.ts
+++ b/src/runtime/node.ts
@@ -1,150 +1,80 @@
 import { BaseLogger } from '../core/logger.ts';
-import { type LogEntry, type LoggerConfig, LogLevel } from '../core/types.ts';
-import { safeStringify } from '../utils/serialization.ts';
+import { createTransports, type Transport } from '../core/transport.ts';
+import type { LogEntry, LoggerConfig } from '../core/types.ts';
 
+/**
+ * Logger for Node.js and Bun.
+ *
+ * Writes through an explicit list of transports built from
+ * `LoggerConfig.transports`. With no transports configured it writes to the
+ * console and nowhere else — file logging is opt-in, never implied by
+ * `NODE_ENV`.
+ *
+ * @example
+ * ```typescript
+ * import { NodeLogger, LogLevel } from 'logan-logger/node';
+ *
+ * const logger = new NodeLogger({
+ *   level: LogLevel.INFO,
+ *   transports: [
+ *     { type: 'console', options: {} },
+ *     { type: 'file', level: LogLevel.ERROR, options: { filename: 'logs/error.log' } },
+ *   ],
+ * });
+ * ```
+ */
 export class NodeLogger extends BaseLogger {
-  // biome-ignore lint/suspicious/noExplicitAny: Winston is an optional peer dependency, types not guaranteed
-  private winston?: any;
+  private readonly transports: Transport[];
 
-  constructor(config: Partial<LoggerConfig> = {}) {
+  /**
+   * @param config - Logger configuration
+   * @param transports - Pre-built transports to adopt instead of building new
+   * ones. Used internally so a child logger shares its parent's destinations.
+   */
+  constructor(config: Partial<LoggerConfig> = {}, transports?: Transport[]) {
     super(config);
-    this.initializeWinston();
+    this.transports = transports ?? createTransports(config);
   }
 
-  private async initializeWinston(): Promise<void> {
-    try {
-      // Try to load Winston if available (optional peer dependency).
-      // Use a dynamic specifier so JSR's publish pipeline won't rewrite the
-      // bare import 'winston' to a relative './winston' path. This keeps
-      // resolution at runtime, where Node will find the npm package if
-      // installed and throw harmlessly otherwise.
-      const winstonModule = 'winston';
-      // biome-ignore lint/suspicious/noTsIgnore: Winston optional dependency - error only exists in CI without Winston
-      // @ts-ignore - Winston is an optional peer dependency, may not be installed in all environments
-      const winston = await import(winstonModule);
-      this.winston = this.createWinstonLogger(winston);
-    } catch (error) {
-      // Winston not available, will fall back to console
-      console.warn('[logan-logger] Winston not found, falling back to console logging:', error);
-    }
+  /** The transports this logger writes through. */
+  getTransports(): readonly Transport[] {
+    return this.transports;
   }
 
-  // biome-ignore lint/suspicious/noExplicitAny: Winston is an optional peer dependency, types not guaranteed
-  private createWinstonLogger(winston: any): any {
-    const logFormat = winston.format.combine(
-      winston.format.timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }),
-      winston.format.errors({ stack: true }),
-      winston.format.json(),
-      winston.format.prettyPrint()
-    );
-
-    const consoleFormat = winston.format.combine(
-      winston.format.colorize(),
-      winston.format.timestamp({ format: 'HH:mm:ss' }),
-      // biome-ignore lint/suspicious/noExplicitAny: Winston format callback parameter has dynamic shape
-      winston.format.printf(({ timestamp, level, message, ...meta }: any) => {
-        const metaStr = Object.keys(meta).length ? JSON.stringify(meta, null, 2) : '';
-        return `${timestamp} [${level}]: ${message} ${metaStr}`;
-      })
-    );
-
-    const logger = winston.createLogger({
-      level: this.getWinstonLevel(this.level),
-      format: logFormat,
-      transports: [
-        new winston.transports.Console({
-          format: process.env.NODE_ENV === 'production' ? logFormat : consoleFormat,
-        }),
-      ],
-    });
-
-    // Add file transports for production
-    if (process.env.NODE_ENV === 'production') {
-      logger.add(
-        new winston.transports.File({
-          filename: 'logs/error.log',
-          level: 'error',
-          maxsize: 5242880, // 5MB
-          maxFiles: 5,
-        })
-      );
-
-      logger.add(
-        new winston.transports.File({
-          filename: 'logs/combined.log',
-          maxsize: 5242880, // 5MB
-          maxFiles: 10,
-        })
-      );
+  /** Release every transport's resources. */
+  close(): void {
+    for (const transport of this.transports) {
+      transport.close?.();
     }
-
-    return logger;
   }
 
   protected writeLog(entry: LogEntry): void {
-    if (this.winston) {
-      this.winston.log({
-        level: this.getWinstonLevel(entry.level),
-        message: entry.message,
-        timestamp: entry.timestamp,
-        ...entry.metadata,
-      });
-    } else {
-      // Fallback to console
-      this.writeToConsole(entry);
+    for (const transport of this.transports) {
+      if (transport.level !== undefined && entry.level < transport.level) {
+        continue;
+      }
+
+      try {
+        transport.write(entry);
+      } catch (error) {
+        // One broken destination must not silence the others.
+        console.warn(`[logan-logger] transport '${transport.type}' failed to write:`, error);
+      }
     }
   }
 
   protected createChild(): BaseLogger {
-    return new NodeLogger(this.config);
-  }
-
-  private writeToConsole(entry: LogEntry): void {
-    const timestamp = entry.timestamp.toISOString();
-    const level = LogLevel[entry.level].toLowerCase();
-    const metaStr = entry.metadata ? ` ${safeStringify(entry.metadata)}` : '';
-    const message = `[${timestamp}] ${level.toUpperCase()}: ${entry.message}${metaStr}`;
-
-    switch (entry.level) {
-      case LogLevel.DEBUG:
-        console.debug(message);
-        break;
-      case LogLevel.INFO:
-        console.info(message);
-        break;
-      case LogLevel.WARN:
-        console.warn(message);
-        break;
-      case LogLevel.ERROR:
-        console.error(message);
-        break;
-    }
-  }
-
-  private getWinstonLevel(level: LogLevel): string {
-    switch (level) {
-      case LogLevel.DEBUG:
-        return 'debug';
-      case LogLevel.INFO:
-        return 'info';
-      case LogLevel.WARN:
-        return 'warn';
-      case LogLevel.ERROR:
-        return 'error';
-      default:
-        return 'info';
-    }
-  }
-
-  setLevel(level: LogLevel): void {
-    super.setLevel(level);
-    if (this.winston) {
-      this.winston.level = this.getWinstonLevel(level);
-    }
+    // Share the transport instances. A per-request child logger must not open
+    // a second handle on the same file.
+    return new NodeLogger(this.config, this.transports);
   }
 }
 
-// Create Morgan-compatible stream
+/**
+ * Create a Morgan-compatible stream that forwards HTTP access logs to a logger.
+ * @param logger - The logger to write through
+ * @returns An object with a `write` method Morgan can use
+ */
 export function createMorganStream(logger: NodeLogger): { write: (message: string) => void } {
   return {
     write: (message: string) => {

--- a/src/utils/config-file.ts
+++ b/src/utils/config-file.ts
@@ -1,0 +1,92 @@
+import type { LoggerConfig } from '../core/types.ts';
+import { detectRuntime } from './runtime.ts';
+
+export async function loadConfigFromFile(configPath?: string): Promise<Partial<LoggerConfig>> {
+  const runtime = detectRuntime();
+
+  if (!runtime.capabilities.fileSystem) {
+    return {};
+  }
+
+  const possiblePaths = configPath
+    ? [configPath]
+    : [
+        'logan.config.json',
+        'logan.config.js',
+        '.loganrc',
+        'package.json', // Check for logan config in package.json
+      ];
+
+  for (const path of possiblePaths) {
+    try {
+      if (runtime.name === 'node') {
+        return await loadNodeConfig(path);
+      } else if (runtime.name === 'deno') {
+        return await loadDenoConfig(path);
+      } else if (runtime.name === 'bun') {
+        return await loadBunConfig(path);
+      }
+    } catch (error) {
+      // Continue to the next path if file doesn't exist or can't be loaded
+      void error; // Suppress unused variable warning
+    }
+  }
+
+  return {};
+}
+
+async function loadNodeConfig(path: string): Promise<Partial<LoggerConfig>> {
+  try {
+    const fs = await import('node:fs/promises');
+    const pathModule = await import('node:path');
+
+    if (path.endsWith('.json')) {
+      const content = await fs.readFile(path, 'utf-8');
+      const parsed = JSON.parse(content);
+
+      if (path === 'package.json') {
+        return parsed.logan || {};
+      }
+      return parsed;
+    } else if (path.endsWith('.js')) {
+      const fullPath = pathModule.resolve(path);
+      // Use file URL for cross-platform dynamic import compatibility
+      const fileUrl = `file://${fullPath}`;
+      const config = await import(/* @vite-ignore */ fileUrl);
+      return config.default || config;
+    }
+  } catch (error) {
+    // File doesn't exist or can't be parsed
+    void error; // Suppress unused variable warning
+  }
+
+  return {};
+}
+
+async function loadDenoConfig(path: string): Promise<Partial<LoggerConfig>> {
+  try {
+    if (path.endsWith('.json')) {
+      // biome-ignore lint/suspicious/noExplicitAny: Deno runtime not in TS types
+      const content = await (globalThis as any).Deno.readTextFile(path);
+      const parsed = JSON.parse(content);
+
+      if (path === 'package.json') {
+        return parsed.logan || {};
+      }
+      return parsed;
+    } else if (path.endsWith('.js')) {
+      const config = await import(/* @vite-ignore */ `./${path}`);
+      return config.default || config;
+    }
+  } catch (error) {
+    // File doesn't exist or can't be parsed
+    void error; // Suppress unused variable warning
+  }
+
+  return {};
+}
+
+async function loadBunConfig(path: string): Promise<Partial<LoggerConfig>> {
+  // Bun can use Node.js-style require or ES modules
+  return loadNodeConfig(path);
+}

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,14 +1,46 @@
 import { type LoggerConfig, LogLevel } from '../core/types.ts';
 import { detectRuntime } from './runtime.ts';
 
-export function getDefaultConfig(): LoggerConfig {
+/**
+ * Whether colored output is appropriate right now.
+ *
+ * `capabilities.colorSupport` answers whether the runtime *can* colorize.
+ * This answers whether it *should*: writing ANSI escapes into a redirected
+ * file or a log shipper is worse than writing none, so a non-TTY stdout
+ * disables color unless the caller forces it. Honors the `NO_COLOR` and
+ * `FORCE_COLOR` conventions.
+ * @returns True when the level token should carry ANSI color
+ */
+export function shouldColorize(): boolean {
   const runtime = detectRuntime();
 
+  if (!runtime.capabilities.colorSupport) {
+    return false;
+  }
+
+  // No process object means a browser, where the console applies its own
+  // styling and there is no stream to pollute.
+  if (typeof process === 'undefined' || !process.env) {
+    return true;
+  }
+
+  if (process.env.NO_COLOR) {
+    return false;
+  }
+
+  if (process.env.FORCE_COLOR) {
+    return process.env.FORCE_COLOR !== '0';
+  }
+
+  return process.stdout?.isTTY === true;
+}
+
+export function getDefaultConfig(): LoggerConfig {
   return {
     level: LogLevel.INFO,
     format: 'text',
     timestamp: true,
-    colorize: runtime.capabilities.colorSupport,
+    colorize: shouldColorize(),
     metadata: {},
     transports: [
       {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -51,129 +51,41 @@ export function getDefaultConfig(): LoggerConfig {
   };
 }
 
-export function loadConfigFromEnvironment(): Partial<LoggerConfig> {
-  const config: Partial<LoggerConfig> = {};
+/** Environment variable values accepted as `true`. */
+const TRUTHY = ['true', '1', 'yes', 'on'];
 
-  // Check for environment variables
-  if (typeof process !== 'undefined' && process.env) {
-    const env = process.env;
+/** Environment variable values accepted as `false`. */
+const FALSY = ['false', '0', 'no', 'off'];
 
-    // Log level
-    if (env.LOG_LEVEL) {
-      config.level = stringToLogLevel(env.LOG_LEVEL);
-    }
+/**
+ * Messages already emitted, so a misconfigured variable warns once rather than
+ * once per logger constructed.
+ */
+const warned = new Set<string>();
 
-    // Format
-    if (env.LOG_FORMAT && ['json', 'text'].includes(env.LOG_FORMAT)) {
-      config.format = env.LOG_FORMAT as 'json' | 'text';
-    }
-
-    // Timestamp
-    if (env.LOG_TIMESTAMP) {
-      config.timestamp = env.LOG_TIMESTAMP.toLowerCase() === 'true';
-    }
-
-    // Colorize
-    if (env.LOG_COLOR) {
-      config.colorize = env.LOG_COLOR.toLowerCase() === 'true';
-    }
+function warnOnce(message: string): void {
+  if (warned.has(message)) {
+    return;
   }
 
-  return config;
+  warned.add(message);
+  console.warn(message);
 }
 
-export async function loadConfigFromFile(configPath?: string): Promise<Partial<LoggerConfig>> {
-  const runtime = detectRuntime();
-
-  if (!runtime.capabilities.fileSystem) {
-    return {};
-  }
-
-  const possiblePaths = configPath
-    ? [configPath]
-    : [
-        'logan.config.json',
-        'logan.config.js',
-        '.loganrc',
-        'package.json', // Check for logan config in package.json
-      ];
-
-  for (const path of possiblePaths) {
-    try {
-      if (runtime.name === 'node') {
-        return await loadNodeConfig(path);
-      } else if (runtime.name === 'deno') {
-        return await loadDenoConfig(path);
-      } else if (runtime.name === 'bun') {
-        return await loadBunConfig(path);
-      }
-    } catch (error) {
-      // Continue to the next path if file doesn't exist or can't be loaded
-      void error; // Suppress unused variable warning
-    }
-  }
-
-  return {};
+/**
+ * Reset the warn-once state. Exposed for tests; not part of the public contract.
+ */
+export function resetEnvironmentWarnings(): void {
+  warned.clear();
 }
 
-async function loadNodeConfig(path: string): Promise<Partial<LoggerConfig>> {
-  try {
-    const fs = await import('node:fs/promises');
-    const pathModule = await import('node:path');
-
-    if (path.endsWith('.json')) {
-      const content = await fs.readFile(path, 'utf-8');
-      const parsed = JSON.parse(content);
-
-      if (path === 'package.json') {
-        return parsed.logan || {};
-      }
-      return parsed;
-    } else if (path.endsWith('.js')) {
-      const fullPath = pathModule.resolve(path);
-      // Use file URL for cross-platform dynamic import compatibility
-      const fileUrl = `file://${fullPath}`;
-      const config = await import(/* @vite-ignore */ fileUrl);
-      return config.default || config;
-    }
-  } catch (error) {
-    // File doesn't exist or can't be parsed
-    void error; // Suppress unused variable warning
-  }
-
-  return {};
-}
-
-async function loadDenoConfig(path: string): Promise<Partial<LoggerConfig>> {
-  try {
-    if (path.endsWith('.json')) {
-      // biome-ignore lint/suspicious/noExplicitAny: Deno runtime not in TS types
-      const content = await (globalThis as any).Deno.readTextFile(path);
-      const parsed = JSON.parse(content);
-
-      if (path === 'package.json') {
-        return parsed.logan || {};
-      }
-      return parsed;
-    } else if (path.endsWith('.js')) {
-      const config = await import(/* @vite-ignore */ `./${path}`);
-      return config.default || config;
-    }
-  } catch (error) {
-    // File doesn't exist or can't be parsed
-    void error; // Suppress unused variable warning
-  }
-
-  return {};
-}
-
-async function loadBunConfig(path: string): Promise<Partial<LoggerConfig>> {
-  // Bun can use Node.js-style require or ES modules
-  return loadNodeConfig(path);
-}
-
-function stringToLogLevel(level: string): LogLevel {
-  switch (level.toLowerCase()) {
+/**
+ * Parse a log level string, reporting failure rather than guessing.
+ * @param level - The value to parse
+ * @returns The matching level, or undefined if the value is not recognized
+ */
+export function tryParseLogLevel(level: string): LogLevel | undefined {
+  switch (level.trim().toLowerCase()) {
     case 'debug':
       return LogLevel.DEBUG;
     case 'info':
@@ -187,8 +99,98 @@ function stringToLogLevel(level: string): LogLevel {
     case 'none':
       return LogLevel.SILENT;
     default:
-      return LogLevel.INFO;
+      return undefined;
   }
+}
+
+/**
+ * Parse a boolean environment variable.
+ *
+ * An unrecognized value yields `undefined` rather than `false`, so a typo falls
+ * through to the next configuration source instead of silently turning the
+ * option off. `LOG_TIMESTAMP=1` disabling timestamps was the previous behavior.
+ */
+function parseBooleanEnvironment(name: string, raw: string): boolean | undefined {
+  const value = raw.trim().toLowerCase();
+
+  if (TRUTHY.includes(value)) {
+    return true;
+  }
+  if (FALSY.includes(value)) {
+    return false;
+  }
+
+  warnOnce(
+    `[logan-logger] ${name}="${raw}" is not a recognized boolean and was ignored. ` +
+      `Accepted: ${TRUTHY.join(', ')} / ${FALSY.join(', ')}.`
+  );
+
+  return undefined;
+}
+
+/**
+ * Read logger configuration from `LOG_LEVEL`, `LOG_FORMAT`, `LOG_TIMESTAMP`
+ * and `LOG_COLOR`.
+ *
+ * Only variables that are set and parse successfully appear in the result, so
+ * an absent or malformed variable leaves lower-precedence sources untouched.
+ *
+ * In a browser these values exist only if the bundler inlined them at build
+ * time; otherwise this returns an empty object.
+ * @returns The subset of configuration the environment specifies
+ */
+export function loadConfigFromEnvironment(): Partial<LoggerConfig> {
+  const config: Partial<LoggerConfig> = {};
+
+  if (typeof process === 'undefined' || !process.env) {
+    return config;
+  }
+
+  const env = process.env;
+
+  if (env.LOG_LEVEL) {
+    const level = tryParseLogLevel(env.LOG_LEVEL);
+
+    if (level === undefined) {
+      warnOnce(
+        `[logan-logger] LOG_LEVEL="${env.LOG_LEVEL}" is not a recognized level and was ` +
+          'ignored. Accepted: debug, info, warn, error, silent.'
+      );
+    } else {
+      config.level = level;
+    }
+  }
+
+  if (env.LOG_FORMAT) {
+    const format = env.LOG_FORMAT.trim().toLowerCase();
+
+    if (format === 'json' || format === 'text') {
+      config.format = format;
+    } else {
+      warnOnce(
+        `[logan-logger] LOG_FORMAT="${env.LOG_FORMAT}" is not a recognized format and was ` +
+          'ignored. Accepted: json, text.'
+      );
+    }
+  }
+
+  if (env.LOG_TIMESTAMP) {
+    const timestamp = parseBooleanEnvironment('LOG_TIMESTAMP', env.LOG_TIMESTAMP);
+
+    if (timestamp !== undefined) {
+      config.timestamp = timestamp;
+    }
+  }
+
+  if (env.LOG_COLOR) {
+    const colorize = parseBooleanEnvironment('LOG_COLOR', env.LOG_COLOR);
+
+    if (colorize !== undefined) {
+      config.colorize = colorize;
+    }
+  }
+
+  return config;
 }
 
 export function mergeConfigs(...configs: Partial<LoggerConfig>[]): LoggerConfig {

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -2,9 +2,20 @@ import { type LogEntry, LogLevel } from '../core/types.ts';
 import { safeStringify } from './serialization.ts';
 
 /**
+ * Presentation options for {@link formatLogEntry}, drawn from `LoggerConfig`.
+ */
+export interface FormatOptions {
+  /** Include the timestamp in the text form. Defaults to `true`. */
+  timestamp?: boolean;
+  /** Apply ANSI colour to the level token in the text form. Defaults to `false`. */
+  colorize?: boolean;
+}
+
+/**
  * Format a log entry for output in different formats.
  * @param entry - The log entry to format
  * @param format - Output format ('json' or 'text')
+ * @param options - Presentation options; they affect the text form only
  * @returns Formatted log string
  * @example
  * ```typescript
@@ -19,12 +30,21 @@ import { safeStringify } from './serialization.ts';
  * const textFormat = formatLogEntry(entry, 'text');
  * // Result: "[2024-01-01T12:00:00.000Z] INFO: User logged in {\"userId\":123}"
  *
+ * const bare = formatLogEntry(entry, 'text', { timestamp: false });
+ * // Result: "INFO: User logged in {\"userId\":123}"
+ *
  * const jsonFormat = formatLogEntry(entry, 'json');
  * // Result: {"timestamp":"2024-01-01T12:00:00.000Z","level":"info","message":"User logged in","metadata":{"userId":123},"runtime":"node"}
  * ```
  */
-export function formatLogEntry(entry: LogEntry, format: 'json' | 'text' = 'text'): string {
+export function formatLogEntry(
+  entry: LogEntry,
+  format: 'json' | 'text' = 'text',
+  options: FormatOptions = {}
+): string {
   if (format === 'json') {
+    // The JSON envelope is machine-readable: it always carries the timestamp
+    // and is never colorized, whatever the config says.
     // biome-ignore lint/suspicious/noExplicitAny: Building dynamic JSON object with optional metadata
     const jsonEntry: any = {
       timestamp: entry.timestamp.toISOString(),
@@ -42,11 +62,11 @@ export function formatLogEntry(entry: LogEntry, format: 'json' | 'text' = 'text'
   }
 
   // Text format
-  const timestamp = entry.timestamp.toISOString();
-  const level = LogLevel[entry.level].toUpperCase();
+  const prefix = options.timestamp === false ? '' : `[${entry.timestamp.toISOString()}] `;
+  const level = formatLevel(entry.level, options.colorize === true);
   const metaStr = entry.metadata ? ` ${safeStringify(entry.metadata)}` : '';
 
-  return `[${timestamp}] ${level}: ${entry.message}${metaStr}`;
+  return `${prefix}${level}: ${entry.message}${metaStr}`;
 }
 
 /**

--- a/src/utils/serialization.ts
+++ b/src/utils/serialization.ts
@@ -1,55 +1,125 @@
 /**
- * Safely stringify an object to JSON, handling circular references,
+ * Maximum traversal depth before `safeStringify` stops descending.
+ * Deeply nested metadata would otherwise recurse until the call stack fails.
+ */
+const DEFAULT_MAX_DEPTH = 100;
+
+/** Options accepted by {@link safeStringify}. */
+export interface SafeStringifyOptions {
+  /** Maximum nesting depth before `'[MaxDepth]'` is emitted. Defaults to 100. */
+  maxDepth?: number;
+}
+
+/**
+ * Build a sanitized clone of `value` with all non-serializable values replaced
+ * by markers.
+ *
+ * `ancestors` holds the objects on the **current path** only. It is unwound in
+ * the `finally` below, so a value is reported as `'[Circular]'` when it is its
+ * own ancestor, not merely because it was encountered earlier somewhere else.
+ * Sibling references to the same object serialize in full at each occurrence.
+ */
+function sanitize(
+  value: unknown,
+  ancestors: Set<object>,
+  depth: number,
+  maxDepth: number
+): unknown {
+  // Substitutions for values JSON cannot represent. `undefined` is intercepted
+  // here because JSON.stringify would otherwise drop the property entirely.
+  if (value === undefined) {
+    return '[undefined]';
+  }
+  if (typeof value === 'bigint') {
+    return `[BigInt: ${value.toString()}]`;
+  }
+  if (typeof value === 'symbol') {
+    return `[Symbol: ${value.toString()}]`;
+  }
+  if (typeof value === 'function') {
+    return `[Function: ${value.name || 'anonymous'}]`;
+  }
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+
+  const container = value as object;
+
+  if (ancestors.has(container)) {
+    return '[Circular]';
+  }
+  if (depth >= maxDepth) {
+    return '[MaxDepth]';
+  }
+
+  ancestors.add(container);
+
+  try {
+    if (container instanceof Error) {
+      return sanitizeEntries(serializeError(container), ancestors, depth, maxDepth);
+    }
+
+    // Mirror JSON.stringify, which consults toJSON before serializing. This is
+    // what keeps Date values as ISO-8601 strings rather than empty objects.
+    const toJSON = (container as { toJSON?: unknown }).toJSON;
+    if (typeof toJSON === 'function') {
+      return sanitize(toJSON.call(container), ancestors, depth, maxDepth);
+    }
+
+    if (Array.isArray(container)) {
+      // Indexed rather than mapped: Array.prototype.map skips holes, and a hole
+      // must still render as '[undefined]'.
+      const items: unknown[] = [];
+      for (let index = 0; index < container.length; index++) {
+        items.push(sanitize(container[index], ancestors, depth + 1, maxDepth));
+      }
+      return items;
+    }
+
+    return sanitizeEntries(container as Record<string, unknown>, ancestors, depth, maxDepth);
+  } finally {
+    ancestors.delete(container);
+  }
+}
+
+function sanitizeEntries(
+  source: Record<string, unknown>,
+  ancestors: Set<object>,
+  depth: number,
+  maxDepth: number
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+
+  for (const [key, entry] of Object.entries(source)) {
+    result[key] = sanitize(entry, ancestors, depth + 1, maxDepth);
+  }
+
+  return result;
+}
+
+/**
+ * Safely stringify a value to JSON, handling circular references,
  * Error objects, functions, and other non-serializable values.
- * @param obj - The object to stringify
+ * @param obj - The value to stringify
  * @param space - Number of spaces for pretty-printing (optional)
+ * @param options - Traversal limits (optional)
  * @returns JSON string representation
+ * @example
+ * ```typescript
+ * const user = { id: 7 };
+ * safeStringify({ actor: user, owner: user });
+ * // {"actor":{"id":7},"owner":{"id":7}} — a repeated reference is not a cycle
+ *
+ * const cyclic: any = {};
+ * cyclic.self = cyclic;
+ * safeStringify(cyclic); // {"self":"[Circular]"}
+ * ```
  */
 // biome-ignore lint/suspicious/noExplicitAny: Serialization utility accepts arbitrary input types
-export function safeStringify(obj: any, space?: number): string {
-  const seen = new WeakSet();
+export function safeStringify(obj: any, space?: number, options: SafeStringifyOptions = {}): string {
+  const maxDepth = options.maxDepth ?? DEFAULT_MAX_DEPTH;
 
-  return JSON.stringify(
-    obj,
-    (_key, value) => {
-      // Handle circular references
-      if (typeof value === 'object' && value !== null) {
-        if (seen.has(value)) {
-          return '[Circular]';
-        }
-        seen.add(value);
-      }
-
-      // Handle Error objects. Delegates to the single shared serializer below
-      // so that safeStringify and serializeError cannot drift apart.
-      if (value instanceof Error) {
-        return serializeError(value);
-      }
-
-      // Handle functions
-      if (typeof value === 'function') {
-        return `[Function: ${value.name || 'anonymous'}]`;
-      }
-
-      // Handle undefined (JSON.stringify normally omits these)
-      if (value === undefined) {
-        return '[undefined]';
-      }
-
-      // Handle BigInt
-      if (typeof value === 'bigint') {
-        return `[BigInt: ${value.toString()}]`;
-      }
-
-      // Handle Symbol
-      if (typeof value === 'symbol') {
-        return `[Symbol: ${value.toString()}]`;
-      }
-
-      return value;
-    },
-    space
-  );
+  return JSON.stringify(sanitize(obj, new Set<object>(), 0, maxDepth), null, space);
 }
 
 /**
@@ -97,17 +167,6 @@ export function filterSensitiveData(
 }
 
 /**
- * Serialize Error objects to plain objects for logging.
- * @param error - The error to serialize
- * @returns Serialized error object or original value if not an Error
- * @example
- * ```typescript
- * const error = new Error('Something went wrong');
- * const serialized = serializeError(error);
- * // Result: { name: 'Error', message: 'Something went wrong', stack: '...' }
- * ```
- */
-/**
  * Properties emitted first, in this order, and never overwritable by a
  * same-named own property on the error.
  */
@@ -135,6 +194,17 @@ function readErrorProperty(error: Error, property: string): unknown {
   return descriptor.value;
 }
 
+/**
+ * Serialize Error objects to plain objects for logging.
+ * @param error - The error to serialize
+ * @returns Serialized error object or original value if not an Error
+ * @example
+ * ```typescript
+ * const error = new Error('Something went wrong');
+ * const serialized = serializeError(error);
+ * // Result: { name: 'Error', message: 'Something went wrong', stack: '...' }
+ * ```
+ */
 // biome-ignore lint/suspicious/noExplicitAny: Error serialization accepts arbitrary error types
 export function serializeError(error: any): any {
   if (!(error instanceof Error)) {

--- a/tests/config-environment.test.ts
+++ b/tests/config-environment.test.ts
@@ -1,0 +1,260 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createLogger, createLoggerForEnvironment } from '../src/core/factory.ts';
+import { type LoggerConfig, LogLevel } from '../src/core/types.ts';
+import { createLogger as createBrowserLogger } from '../src/browser.ts';
+import { resetEnvironmentWarnings } from '../src/utils/config.ts';
+
+const LOG_VARIABLES = ['LOG_LEVEL', 'LOG_FORMAT', 'LOG_TIMESTAMP', 'LOG_COLOR'] as const;
+
+let saved: Record<string, string | undefined>;
+
+/** Capture whatever the logger writes to the console, whichever method it uses. */
+function captureConsole() {
+  const lines: string[] = [];
+  const record = (value: unknown) => {
+    lines.push(String(value));
+  };
+
+  for (const method of ['debug', 'info', 'warn', 'error'] as const) {
+    vi.spyOn(console, method).mockImplementation(record);
+  }
+
+  return lines;
+}
+
+beforeEach(() => {
+  saved = {};
+  for (const name of LOG_VARIABLES) {
+    saved[name] = process.env[name];
+    delete process.env[name];
+  }
+  resetEnvironmentWarnings();
+});
+
+afterEach(() => {
+  for (const name of LOG_VARIABLES) {
+    if (saved[name] === undefined) {
+      delete process.env[name];
+    } else {
+      process.env[name] = saved[name];
+    }
+  }
+  vi.restoreAllMocks();
+});
+
+describe('environment variables reach the logger', () => {
+  it('should apply LOG_LEVEL', () => {
+    process.env.LOG_LEVEL = 'debug';
+
+    expect(createLogger().getLevel()).toBe(LogLevel.DEBUG);
+  });
+
+  it('should silence everything at LOG_LEVEL=silent', () => {
+    process.env.LOG_LEVEL = 'silent';
+    const lines = captureConsole();
+
+    const logger = createLogger();
+    logger.debug('d');
+    logger.info('i');
+    logger.warn('w');
+    logger.error('e');
+
+    expect(lines).toEqual([]);
+  });
+
+  it('should apply LOG_FORMAT=json', () => {
+    process.env.LOG_FORMAT = 'json';
+    const lines = captureConsole();
+
+    createLogger().info('structured');
+
+    expect(JSON.parse(lines[0]).message).toBe('structured');
+  });
+
+  it('should apply LOG_TIMESTAMP=false', () => {
+    process.env.LOG_TIMESTAMP = 'false';
+    const lines = captureConsole();
+
+    createLogger().info('no clock');
+
+    expect(lines[0]).toBe('INFO: no clock');
+  });
+
+  it('should apply LOG_COLOR in both directions', () => {
+    const escape = String.fromCharCode(27);
+
+    process.env.LOG_COLOR = 'true';
+    let lines = captureConsole();
+    createLogger().error('red');
+    expect(lines[0]).toContain(escape);
+
+    vi.restoreAllMocks();
+
+    process.env.LOG_COLOR = 'false';
+    lines = captureConsole();
+    createLogger().error('plain');
+    expect(lines[0]).not.toContain(escape);
+  });
+});
+
+describe('precedence', () => {
+  it('should let the environment override explicit config', () => {
+    process.env.LOG_LEVEL = 'debug';
+
+    expect(createLogger({ level: LogLevel.ERROR }).getLevel()).toBe(LogLevel.DEBUG);
+  });
+
+  it('should leave explicit config alone when the variable is unset', () => {
+    expect(createLogger({ level: LogLevel.ERROR }).getLevel()).toBe(LogLevel.ERROR);
+  });
+
+  it('should honor ignoreEnvironment', () => {
+    process.env.LOG_LEVEL = 'debug';
+
+    expect(
+      createLogger({ level: LogLevel.ERROR, ignoreEnvironment: true }).getLevel()
+    ).toBe(LogLevel.ERROR);
+  });
+
+  it('should let LOG_LEVEL override the NODE_ENV-derived level', () => {
+    const original = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+    process.env.LOG_LEVEL = 'debug';
+
+    try {
+      expect(createLoggerForEnvironment().getLevel()).toBe(LogLevel.DEBUG);
+    } finally {
+      process.env.NODE_ENV = original;
+    }
+  });
+
+  it('should apply the same rules from the browser entry point', () => {
+    process.env.LOG_LEVEL = 'error';
+
+    expect(createBrowserLogger().getLevel()).toBe(LogLevel.ERROR);
+    expect(createBrowserLogger({ ignoreEnvironment: true }).getLevel()).toBe(LogLevel.INFO);
+  });
+});
+
+describe('malformed values', () => {
+  it('should treat LOG_TIMESTAMP=1 as true rather than false', () => {
+    process.env.LOG_TIMESTAMP = '1';
+    const lines = captureConsole();
+
+    createLogger().info('kept');
+
+    // The strict `=== 'true'` rule made every non-"true" value mean false, so
+    // LOG_TIMESTAMP=1 silently removed timestamps.
+    expect(lines[0]).toMatch(/^\[\d{4}-/);
+  });
+
+  it.each(['yes', 'on', 'TRUE', ' true '])('should accept %s as true', (value) => {
+    process.env.LOG_COLOR = value;
+    const lines = captureConsole();
+
+    createLogger().error('colored');
+
+    expect(lines[0]).toContain(String.fromCharCode(27));
+  });
+
+  it.each(['no', 'off', '0', 'FALSE'])('should accept %s as false', (value) => {
+    process.env.LOG_COLOR = value;
+    const lines = captureConsole();
+
+    createLogger().error('plain');
+
+    expect(lines[0]).not.toContain(String.fromCharCode(27));
+  });
+
+  it('should warn and fall through to explicit config rather than choosing a side', () => {
+    process.env.LOG_TIMESTAMP = 'banana';
+    const lines = captureConsole();
+
+    createLogger({ timestamp: false }).info('x');
+
+    expect(lines.some((line) => line.includes('LOG_TIMESTAMP="banana"'))).toBe(true);
+    // The explicit timestamp:false survives; the bad value does not flip it.
+    expect(lines).toContain('INFO: x');
+  });
+
+  it('should warn and ignore an unrecognized LOG_LEVEL rather than defaulting to INFO', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    process.env.LOG_LEVEL = 'verbose';
+
+    expect(createLogger({ level: LogLevel.ERROR }).getLevel()).toBe(LogLevel.ERROR);
+    expect(warn.mock.calls[0][0]).toContain('LOG_LEVEL="verbose"');
+  });
+
+  it('should warn and ignore an unrecognized LOG_FORMAT', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    process.env.LOG_FORMAT = 'yaml';
+
+    createLogger().info('x');
+
+    expect(warn.mock.calls[0][0]).toContain('LOG_FORMAT="yaml"');
+  });
+
+  it('should warn once, not once per logger', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    process.env.LOG_LEVEL = 'verbose';
+
+    createLogger();
+    createLogger();
+    createLogger();
+
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+});
+
+/**
+ * The guard #60 asked for: a declared config field that nothing reads is
+ * indistinguishable from a working one. Every field must move the output.
+ *
+ * `transports` and `ignoreEnvironment` are covered by their own suites
+ * (tests/node-logger.test.ts and the precedence block above) because their
+ * effect is not a change to a single emitted line.
+ */
+describe('every LoggerConfig field measurably changes output', () => {
+  const cases: Array<{
+    field: keyof LoggerConfig;
+    baseline: Partial<LoggerConfig>;
+    changed: Partial<LoggerConfig>;
+  }> = [
+    { field: 'level', baseline: { level: LogLevel.DEBUG }, changed: { level: LogLevel.ERROR } },
+    { field: 'format', baseline: { format: 'text' }, changed: { format: 'json' } },
+    { field: 'timestamp', baseline: { timestamp: true }, changed: { timestamp: false } },
+    { field: 'colorize', baseline: { colorize: false }, changed: { colorize: true } },
+    { field: 'metadata', baseline: { metadata: {} }, changed: { metadata: { service: 'api' } } },
+  ];
+
+  it.each(cases)('$field', ({ baseline, changed }) => {
+    const emit = (config: Partial<LoggerConfig>) => {
+      const lines = captureConsole();
+      const logger = createLogger({ level: LogLevel.DEBUG, ...config, ignoreEnvironment: true });
+      logger.debug('probe');
+      vi.restoreAllMocks();
+      return lines.join('\n');
+    };
+
+    expect(emit(baseline)).not.toBe(emit(changed));
+  });
+
+  it('should include config.metadata on every record', () => {
+    const lines = captureConsole();
+
+    createLogger({ metadata: { service: 'api' }, ignoreEnvironment: true }).info('with defaults');
+
+    expect(lines[0]).toContain('"service":"api"');
+  });
+
+  it('should let call-site metadata override config.metadata', () => {
+    const lines = captureConsole();
+
+    createLogger({ metadata: { stage: 'default' }, ignoreEnvironment: true }).info('x', {
+      stage: 'override',
+    });
+
+    expect(lines[0]).toContain('"stage":"override"');
+    expect(lines[0]).not.toContain('default');
+  });
+});

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,10 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { logLevelToString, stringToLogLevel } from '../src/core/factory.ts';
 import { type LoggerConfig, LogLevel } from '../src/core/types.ts';
+import { loadConfigFromFile } from '../src/utils/config-file.ts';
 import {
   getDefaultConfig,
   loadConfigFromEnvironment,
-  loadConfigFromFile,
   mergeConfigs,
 } from '../src/utils/config.ts';
 

--- a/tests/file-transport.test.ts
+++ b/tests/file-transport.test.ts
@@ -1,0 +1,191 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { LogLevel } from '../src/core/types.ts';
+// Importing this module registers the 'file' transport.
+import { FileTransport } from '../src/runtime/file-transport.ts';
+import { NodeLogger } from '../src/runtime/node.ts';
+
+let workspace: string;
+
+function entry(message: string, level: LogLevel = LogLevel.INFO) {
+  return {
+    timestamp: new Date('2026-08-22T04:15:30.123Z'),
+    level,
+    message,
+    runtime: 'node' as const,
+  };
+}
+
+beforeEach(() => {
+  workspace = mkdtempSync(join(tmpdir(), 'logan-file-transport-'));
+});
+
+afterEach(() => {
+  rmSync(workspace, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe('FileTransport', () => {
+  it('should touch the filesystem only on the first write', () => {
+    const target = join(workspace, 'nested', 'deeper', 'app.log');
+    const transport = new FileTransport({ filename: target });
+
+    expect(existsSync(join(workspace, 'nested'))).toBe(false);
+
+    transport.write(entry('first line'));
+    transport.close();
+
+    expect(existsSync(target)).toBe(true);
+  });
+
+  it('should append one JSON envelope per line by default', () => {
+    const target = join(workspace, 'app.log');
+    const transport = new FileTransport({ filename: target });
+
+    transport.write(entry('one'));
+    transport.write(entry('two'));
+    transport.close();
+
+    const lines = readFileSync(target, 'utf-8').trim().split('\n');
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[0])).toEqual({
+      timestamp: '2026-08-22T04:15:30.123Z',
+      level: 'info',
+      message: 'one',
+      runtime: 'node',
+    });
+    expect(JSON.parse(lines[1]).message).toBe('two');
+  });
+
+  it('should write the text form when asked, never colorized', () => {
+    const target = join(workspace, 'app.log');
+    const transport = new FileTransport({ filename: target, format: 'text' });
+
+    transport.write(entry('plain'));
+    transport.close();
+
+    expect(readFileSync(target, 'utf-8')).toBe('[2026-08-22T04:15:30.123Z] INFO: plain\n');
+  });
+
+  it('should rotate once the active file reaches maxsize', () => {
+    const target = join(workspace, 'app.log');
+    const transport = new FileTransport({ filename: target, maxsize: 120, maxFiles: 3 });
+
+    for (let index = 0; index < 8; index++) {
+      transport.write(entry(`message-${index}`));
+    }
+    transport.close();
+
+    expect(existsSync(`${target}.1`)).toBe(true);
+    expect(statSync(target).size).toBeLessThanOrEqual(120 + 200);
+  });
+
+  it('should keep at most maxFiles archives and drop the oldest', () => {
+    const target = join(workspace, 'app.log');
+    const transport = new FileTransport({ filename: target, maxsize: 60, maxFiles: 2 });
+
+    for (let index = 0; index < 20; index++) {
+      transport.write(entry(`message-${index}`));
+    }
+    transport.close();
+
+    expect(existsSync(`${target}.1`)).toBe(true);
+    expect(existsSync(`${target}.2`)).toBe(true);
+    expect(existsSync(`${target}.3`)).toBe(false);
+  });
+
+  it('should keep the newest archive as .1 after rotating', () => {
+    const target = join(workspace, 'app.log');
+    const transport = new FileTransport({ filename: target, maxsize: 60, maxFiles: 3 });
+
+    transport.write(entry('oldest'));
+    transport.write(entry('middle'));
+    transport.write(entry('newest'));
+    transport.close();
+
+    expect(readFileSync(`${target}.1`, 'utf-8')).toContain('middle');
+    expect(readFileSync(target, 'utf-8')).toContain('newest');
+  });
+
+  it('should warn once, naming the path, when the destination is not writable', () => {
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // A file where a directory is required: mkdir then open must fail.
+    const blocker = join(workspace, 'blocked');
+    mkdirSync(workspace, { recursive: true });
+    const transport = new FileTransport({ filename: join(blocker, 'app.log') });
+    // Create `blocked` as a regular file so `blocked/app.log` cannot exist.
+    new FileTransport({ filename: blocker }).write(entry('occupy'));
+
+    expect(() => transport.write(entry('doomed'))).not.toThrow();
+    expect(() => transport.write(entry('doomed again'))).not.toThrow();
+
+    expect(consoleSpy).toHaveBeenCalledTimes(1);
+    const [message, detail] = consoleSpy.mock.calls[0];
+    expect(message).toContain(join(blocker, 'app.log'));
+    expect(String(detail)).toMatch(/ENOTDIR|EEXIST|ENOENT|EACCES/);
+  });
+
+  it('should reject construction without a filename', () => {
+    expect(() => new FileTransport({} as { filename: string })).toThrow(/filename/);
+  });
+});
+
+describe('NodeLogger with a file transport', () => {
+  it('should write only what passes the transport level filter', () => {
+    const target = join(workspace, 'error.log');
+    const logger = new NodeLogger({
+      level: LogLevel.DEBUG,
+      transports: [{ type: 'file', level: LogLevel.ERROR, options: { filename: target } }],
+    });
+
+    logger.info('ignored');
+    logger.error('kept');
+    logger.close();
+
+    const lines = readFileSync(target, 'utf-8').trim().split('\n');
+    expect(lines).toHaveLength(1);
+    expect(JSON.parse(lines[0]).message).toBe('kept');
+  });
+
+  it('should open exactly one handle however many children are created', () => {
+    const target = join(workspace, 'app.log');
+    const logger = new NodeLogger({
+      transports: [{ type: 'file', options: { filename: target } }],
+    });
+
+    const children = Array.from({ length: 50 }, (_, index) =>
+      logger.child({ requestId: `req-${index}` })
+    );
+
+    for (const child of children) {
+      expect((child as NodeLogger).getTransports()).toEqual(logger.getTransports());
+    }
+
+    children[0].info('from a child');
+    logger.close();
+
+    const lines = readFileSync(target, 'utf-8').trim().split('\n');
+    expect(lines).toHaveLength(1);
+    expect(JSON.parse(lines[0]).metadata).toEqual({ requestId: 'req-0' });
+  });
+
+  it('should fan out to console and file together', () => {
+    const consoleSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const target = join(workspace, 'app.log');
+
+    const logger = new NodeLogger({
+      transports: [
+        { type: 'console', options: {} },
+        { type: 'file', options: { filename: target } },
+      ],
+    });
+
+    logger.info('both');
+    logger.close();
+
+    expect(consoleSpy).toHaveBeenCalledTimes(1);
+    expect(readFileSync(target, 'utf-8')).toContain('both');
+  });
+});

--- a/tests/node-logger.test.ts
+++ b/tests/node-logger.test.ts
@@ -1,6 +1,20 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { type LoggerConfig, LogLevel } from '../src/core/types.ts';
+import type { Transport } from '../src/core/transport.ts';
+import { type LogEntry, type LoggerConfig, LogLevel } from '../src/core/types.ts';
 import { createMorganStream, NodeLogger } from '../src/runtime/node.ts';
+
+/** A transport that keeps what it was given, for assertions. */
+function recordingTransport(): Transport & { entries: LogEntry[] } {
+  const entries: LogEntry[] = [];
+
+  return {
+    type: 'recording',
+    entries,
+    write(entry: LogEntry) {
+      entries.push(entry);
+    },
+  };
+}
 
 describe('Node.js Logger', () => {
   beforeEach(() => {
@@ -30,12 +44,7 @@ describe('Node.js Logger', () => {
       expect(logger.getLevel()).toBe(LogLevel.WARN);
     });
 
-    it('should fall back to console when Winston is not available', () => {
-      // Mock Winston import failure
-      vi.mock('winston', () => {
-        throw new Error('Winston not found');
-      });
-
+    it('should write to the console when no transports are configured', () => {
       const consoleSpy = {
         debug: vi.spyOn(console, 'debug').mockImplementation(() => {}),
         info: vi.spyOn(console, 'info').mockImplementation(() => {}),
@@ -260,27 +269,154 @@ describe('Node.js Logger', () => {
     });
   });
 
-  describe('Winston integration', () => {
-    it('should handle Winston initialization gracefully', async () => {
-      // This test mainly ensures the async Winston loading doesn't break
-      const logger = new NodeLogger();
+  describe('transports', () => {
+    it('should emit the very first record, with no async initialization window', () => {
+      const consoleSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
 
-      // Give time for async Winston initialization
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      // Regression test: the Winston implementation kicked off an un-awaited
+      // dynamic import in its constructor, so records logged before it
+      // resolved silently took a different path.
+      new NodeLogger({ level: LogLevel.DEBUG }).info('first');
 
-      expect(logger).toBeDefined();
+      expect(consoleSpy).toHaveBeenCalledTimes(1);
+      expect(consoleSpy.mock.calls[0][0]).toContain('first');
     });
 
-    it('should map log levels correctly for Winston', () => {
-      const logger = new NodeLogger();
+    it('should route each level to the matching console method', () => {
+      const spies = {
+        debug: vi.spyOn(console, 'debug').mockImplementation(() => {}),
+        info: vi.spyOn(console, 'info').mockImplementation(() => {}),
+        warn: vi.spyOn(console, 'warn').mockImplementation(() => {}),
+        error: vi.spyOn(console, 'error').mockImplementation(() => {}),
+      };
 
-      // Test that all log levels work (even if Winston isn't available)
-      expect(() => {
-        logger.debug('debug');
-        logger.info('info');
-        logger.warn('warn');
-        logger.error('error');
-      }).not.toThrow();
+      const logger = new NodeLogger({ level: LogLevel.DEBUG });
+      logger.debug('d');
+      logger.info('i');
+      logger.warn('w');
+      logger.error('e');
+
+      expect(spies.debug).toHaveBeenCalledTimes(1);
+      expect(spies.info).toHaveBeenCalledTimes(1);
+      expect(spies.warn).toHaveBeenCalledTimes(1);
+      expect(spies.error).toHaveBeenCalledTimes(1);
+    });
+
+    it('should build exactly the transports listed, in order', () => {
+      const first = recordingTransport();
+      const second = recordingTransport();
+
+      const logger = new NodeLogger({
+        transports: [
+          { type: 'custom', options: { transport: first } },
+          { type: 'custom', options: { transport: second } },
+        ],
+      });
+
+      expect(logger.getTransports()).toHaveLength(2);
+      expect(logger.getTransports()[0]).toBe(first);
+      expect(logger.getTransports()[1]).toBe(second);
+    });
+
+    it('should apply a per-transport level filter', () => {
+      const quiet = recordingTransport();
+
+      const logger = new NodeLogger({
+        level: LogLevel.DEBUG,
+        transports: [{ type: 'custom', level: LogLevel.ERROR, options: { transport: quiet } }],
+      });
+
+      logger.info('ignored');
+      logger.error('kept');
+
+      expect(quiet.entries.map((entry) => entry.message)).toEqual(['kept']);
+    });
+
+    it('should keep writing through healthy transports when one throws', () => {
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const healthy = recordingTransport();
+      const broken = {
+        type: 'broken',
+        write() {
+          throw new Error('destination is on fire');
+        },
+      };
+
+      const logger = new NodeLogger({
+        transports: [
+          { type: 'custom', options: { transport: broken } },
+          { type: 'custom', options: { transport: healthy } },
+        ],
+      });
+
+      expect(() => logger.info('still logged')).not.toThrow();
+      expect(healthy.entries).toHaveLength(1);
+      expect(consoleSpy).toHaveBeenCalled();
+    });
+
+    it('should keep the other transports when one fails to initialize', () => {
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const healthy = recordingTransport();
+
+      const logger = new NodeLogger({
+        transports: [
+          // No options.transport: the custom factory rejects this one.
+          { type: 'custom', options: {} },
+          { type: 'custom', options: { transport: healthy } },
+        ],
+      });
+
+      expect(logger.getTransports()).toEqual([healthy]);
+      expect(consoleSpy).toHaveBeenCalled();
+    });
+
+    it('should warn with an actionable message for an unregistered file transport', () => {
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      // tests/file-transport.test.ts imports the module that registers 'file';
+      // this file deliberately does not, matching a main-entry consumer.
+      const logger = new NodeLogger({
+        transports: [{ type: 'file', options: { filename: 'logs/should-not-exist.log' } }],
+      });
+
+      expect(logger.getTransports()).toHaveLength(0);
+      expect(consoleSpy.mock.calls[0][0]).toContain("logan-logger/node");
+    });
+
+    it('should share transports with child loggers rather than rebuilding them', () => {
+      const shared = recordingTransport();
+      const parent = new NodeLogger({ transports: [{ type: 'custom', options: { transport: shared } }] });
+
+      const child = parent.child({ requestId: 'req-1' }) as NodeLogger;
+      const grandchild = child.child({ span: 'a' }) as NodeLogger;
+
+      expect(child.getTransports()[0]).toBe(shared);
+      expect(grandchild.getTransports()[0]).toBe(shared);
+
+      child.info('from child');
+
+      expect(shared.entries).toHaveLength(1);
+      expect(shared.entries[0].metadata).toEqual({ requestId: 'req-1' });
+    });
+
+    it('should honor config.timestamp and config.colorize in the text form', () => {
+      const consoleSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+
+      new NodeLogger({ timestamp: false, colorize: false }).info('bare');
+
+      expect(consoleSpy.mock.calls[0][0]).toBe('INFO: bare');
+    });
+
+    it('should emit the JSON envelope when format is json, never colorized', () => {
+      const consoleSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+
+      new NodeLogger({ format: 'json', colorize: true }).info('structured', { a: 1 });
+
+      const parsed = JSON.parse(consoleSpy.mock.calls[0][0]);
+      expect(parsed.level).toBe('info');
+      expect(parsed.message).toBe('structured');
+      expect(parsed.metadata).toEqual({ a: 1 });
+      expect(consoleSpy.mock.calls[0][0]).not.toContain('\u001b[');
     });
   });
 
@@ -297,6 +433,10 @@ describe('Node.js Logger', () => {
         expect(() => {
           logger.error('Production error');
         }).not.toThrow();
+
+        // NODE_ENV=production must not imply file logging. The implicit file
+        // transports were the cause of #44.
+        expect(logger.getTransports().map((transport) => transport.type)).toEqual(['console']);
       } finally {
         process.env.NODE_ENV = originalEnv;
       }

--- a/tests/serialization.test.ts
+++ b/tests/serialization.test.ts
@@ -388,4 +388,121 @@ describe('Serialization Utilities', () => {
       );
     });
   });
+
+  describe('safeStringify cycle detection (#57)', () => {
+    it('should serialize a repeated sibling reference in full, not as [Circular]', () => {
+      const user = { id: 7, name: 'jo' };
+
+      const result = safeStringify({ actor: user, owner: user });
+
+      expect(JSON.parse(result)).toEqual({
+        actor: { id: 7, name: 'jo' },
+        owner: { id: 7, name: 'jo' },
+      });
+      expect(result).not.toContain('[Circular]');
+    });
+
+    it('should still report a direct self-reference as [Circular]', () => {
+      const node: any = { name: 'root' };
+      node.self = node;
+
+      expect(JSON.parse(safeStringify(node))).toEqual({ name: 'root', self: '[Circular]' });
+    });
+
+    it('should still report an indirect cycle as [Circular]', () => {
+      const parent: any = { name: 'parent' };
+      parent.child = { name: 'child', parent };
+
+      expect(JSON.parse(safeStringify(parent))).toEqual({
+        name: 'parent',
+        child: { name: 'child', parent: '[Circular]' },
+      });
+    });
+
+    it('should serialize the same object twice inside one array', () => {
+      const entity = { id: 1 };
+
+      expect(JSON.parse(safeStringify([entity, entity]))).toEqual([{ id: 1 }, { id: 1 }]);
+    });
+
+    it('should handle a cycle and a repeated reference in the same payload', () => {
+      const shared = { kind: 'shared' };
+      const root: any = { a: shared, b: shared };
+      root.loop = root;
+
+      expect(JSON.parse(safeStringify(root))).toEqual({
+        a: { kind: 'shared' },
+        b: { kind: 'shared' },
+        loop: '[Circular]',
+      });
+    });
+
+    it('should serialize a repeated Error instance at every occurrence', () => {
+      const error = new Error('boom');
+      error.stack = 'STACK';
+
+      const parsed = JSON.parse(safeStringify({ first: error, second: error }));
+
+      expect(parsed.first).toEqual({ name: 'Error', message: 'boom', stack: 'STACK' });
+      expect(parsed.second).toEqual(parsed.first);
+    });
+
+    it('should serialize an error and its cause when both reference a shared object', () => {
+      const request = { id: 'req-1' };
+      const cause = new Error('underlying') as any;
+      cause.stack = 'CAUSE_STACK';
+      cause.request = request;
+      const error = new Error('wrapper', { cause }) as any;
+      error.stack = 'STACK';
+      error.request = request;
+
+      const parsed = JSON.parse(safeStringify(error));
+
+      expect(parsed.request).toEqual({ id: 'req-1' });
+      expect(parsed.cause.request).toEqual({ id: 'req-1' });
+    });
+
+    it('should keep [undefined] for object properties and array holes', () => {
+      expect(safeStringify({ a: undefined })).toBe('{"a":"[undefined]"}');
+      expect(safeStringify([1, , 3])).toBe('[1,"[undefined]",3]');
+      expect(safeStringify(undefined)).toBe('"[undefined]"');
+    });
+
+    it('should leave top-level primitives, null, arrays and empty objects unchanged', () => {
+      expect(safeStringify('str')).toBe('"str"');
+      expect(safeStringify(42)).toBe('42');
+      expect(safeStringify(true)).toBe('true');
+      expect(safeStringify(null)).toBe('null');
+      expect(safeStringify([])).toBe('[]');
+      expect(safeStringify({})).toBe('{}');
+    });
+
+    it('should preserve Date values as ISO strings', () => {
+      const when = new Date('2026-08-22T04:15:30.123Z');
+
+      expect(safeStringify({ when })).toBe('{"when":"2026-08-22T04:15:30.123Z"}');
+    });
+
+    it('should emit [MaxDepth] instead of blowing the stack on deep nesting', () => {
+      const root: any = {};
+      let cursor = root;
+      for (let i = 0; i < 5000; i++) {
+        cursor.next = {};
+        cursor = cursor.next;
+      }
+
+      let result = '';
+      expect(() => {
+        result = safeStringify(root);
+      }).not.toThrow();
+      expect(result).toContain('[MaxDepth]');
+      expect(() => JSON.parse(result)).not.toThrow();
+    });
+
+    it('should respect an explicit maxDepth', () => {
+      const value = { a: { b: { c: 1 } } };
+
+      expect(safeStringify(value, undefined, { maxDepth: 2 })).toBe('{"a":{"b":"[MaxDepth]"}}');
+    });
+  });
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -40,26 +40,21 @@ export default defineConfig({
       name: 'LoganLogger',
     },
     rollupOptions: {
-      // External dependencies that shouldn't be bundled
-      external: ['winston'],
+      // Node built-ins are resolved by the runtime, never bundled. Only the
+      // node and bun entry points reach them; the browser entry does not.
+      external: [/^node:/],
       output: [
         {
           format: 'es',
           exports: 'named',
           entryFileNames: '[name].mjs',
           chunkFileNames: 'chunks/[name]-[hash].mjs',
-          globals: {
-            winston: 'winston',
-          },
         },
         {
           format: 'cjs',
           exports: 'named',
           entryFileNames: '[name].cjs',
           chunkFileNames: 'chunks/[name]-[hash].cjs',
-          globals: {
-            winston: 'winston',
-          },
         },
       ],
     },


### PR DESCRIPTION
Closes #47. Closes #57. Closes #60. Closes #44. Closes #42.
Refs #65, #67 — fixed here, kept open to track the 1.x backport.

**Do not merge until 2.0.0's contents are settled — merging publishes to npm and JSR immediately.** The squash-merge message must keep the `feat!:` marker (or a `BREAKING CHANGE:` line) or the release workflow will cut a patch instead of a major.

---

## What this does

Four fixes that are all behaviour changes, which is why they ride together in one major.

### #47 — Winston is gone

`NodeLogger` no longer imports anything. It writes through a list of transports built from `LoggerConfig.transports`, which has been declared and ignored since 1.0.

- **`src/core/transport.ts`** — the `Transport` interface, a type registry (`registerTransport`), `ConsoleTransport`, and `createTransports()`
- **`src/runtime/file-transport.ts`** — `FileTransport`: size-based rotation, lazy directory creation, `writeSync` against a held fd
- **`src/runtime/node.ts`** — 154 lines down to 84, fully synchronous, no dynamic imports

Beyond the dependency count, removing Winston deletes four defects structurally:

| | |
|---|---|
| **#42** | The `const winstonModule = 'winston'` indirection existed only to defeat JSR's static analyzer. No import, no workaround. `deno publish --dry-run` now reports zero `unanalyzable-dynamic-import` warnings against `node.ts` — the only one left in the package is the config-file loader's `fileUrl` import. |
| **#44** | Both halves. `mkdirSync('logs')` no longer fires for every logger built under `NODE_ENV=production`, and `config.transports` is honored. File logging is now **opt-in**. |
| **unreported (a)** | The constructor kicked off an un-awaited `initializeWinston()`, and `writeLog` guarded on `if (this.winston)`. Every record emitted before that import resolved silently took the console fallback — different format, bypassing the file transports. Regression test: `should emit the very first record, with no async initialization window`. |
| **unreported (b)** | `createChild()` called `new NodeLogger(this.config)`, which ran `initializeWinston()` again — a fresh Winston instance and, under `NODE_ENV=production`, **two more file handles on the same files, per child**. Child loggers are the documented per-request pattern. Children now share the parent's transport instances. |

Guarding: each transport is built behind its own `try`, and written to behind its own `try`. One bad destination can neither prevent the others from being created nor stop them being written to.

**Browser safety.** `node:fs` is imported statically by `file-transport.ts`, which is reached only from `src/node.ts` and `src/bun.ts` — those entry points are what register the `file` transport. Configure a `file` transport from the main entry and you get a warning naming the entry point to import instead.

### #57 — `[Circular]` now means circular

`safeStringify` added every visited object to a `WeakSet` that was never unwound, so a value referenced twice as siblings — a DAG, not a cycle — emitted `"[Circular]"` on the second occurrence and lost the data.

Replaced the replacer-based approach with a direct traversal that builds a sanitized clone, tracking only the objects on the **current path** and deleting them in a `finally` on the way out. Genuine cycles still terminate. Added a 100-level depth guard emitting `"[MaxDepth]"` rather than overflowing the stack, overridable via `safeStringify(value, space, { maxDepth })`.

`Date` and any other `toJSON` holder still serialize the way `JSON.stringify` would, array holes still render as `"[undefined]"`, and the error path still routes through the single `serializeError` unified in #63.

### #60 — `timestamp` and `colorize` do something

`formatLogEntry` takes a third `FormatOptions` argument, and the console transport passes the config through. Both apply to the **text** form only; the JSON envelope always carries a timestamp and is never colorized.

`colorize` additionally defers to the terminal: ANSI escapes are suppressed when stdout is not a TTY, honoring `NO_COLOR` and `FORCE_COLOR`. Without that gate, fixing #60 would have started writing escape codes into every redirected log file, which is worse than the bug. That gating is spec-relevant and is raised as llbbl/treering#1.

### #65 and #67 — configuration that was parsed but never applied

`loadConfigFromEnvironment()` read all four `LOG_*` variables correctly and was unit-tested; nothing in `src/` ever called it. `LoggerConfig.metadata` had the same defect one layer deeper — merged carefully by `getDefaultConfig()`, `LoggerFactory.mergeConfig` and `mergeConfigs()`, then never read by `BaseLogger`.

- `LoggerFactory.mergeConfig` now uses the existing `mergeConfigs()` — variadic, precedence-aware, previously called from nowhere — and folds the environment in at the top: `defaults < explicit config < environment`. That is the order four documents already promised. New `LoggerConfig.ignoreEnvironment` opts out, for a library that must pin its own logging against a host application's environment.
- `BaseLogger` seeds `childMetadata` from `config.metadata`, so it lands on every record and inherits through `child()`. Call-site metadata still wins.
- **Boolean parsing was a trap waiting to spring.** `LOG_TIMESTAMP=1` resolved to `false` under the old `=== 'true'` rule — harmless only because nothing read it. Now accepts `true/1/yes/on` and `false/0/no/off`.
- An unparseable value for any of the four is **ignored with a one-time warning**, falling through to the next source rather than resolving to a default. `LOG_LEVEL=verbose` no longer silently becomes `info`.
- Level parsing existed in two places; `factory.stringToLogLevel` now delegates to the single parser in `utils/config.ts`.
- `src/browser.ts` duplicated the entire default-config path and had the same hole. It now shares `utils/config.ts`.

**`src/utils/config.ts` is split** so the pure half (defaults, environment, merging) carries no Node specifiers and is safe for the browser entry to import. The file loaders move to `src/utils/config-file.ts`, still re-exported from the index, deno and bun entry points — the public API is unchanged. Net effect on the build:

```
dist/browser.mjs   -> chunks/config.mjs                          (no node: specifier at all)
dist/index.mjs     -> chunks/config.mjs, config-file.mjs, factory.mjs
chunks/config.mjs        (none)
chunks/config-file.mjs   node:fs/promises, node:path   — dynamic import() only
chunks/file-transport    node:fs, node:path            — static, reached only from node/bun
```

The browser bundle previously reached `node:fs/promises` through the factory chunk. It no longer references any Node specifier.

**#65 and #67 are referenced, not closed** — both need a 1.x backport.

## Tests

238 passing, up from 189.

- `tests/config-environment.test.ts` (new, 30) — each variable reaching a logger, `LOG_LEVEL=silent` emitting nothing, environment over explicit config, `ignoreEnvironment`, `LOG_LEVEL` over the `NODE_ENV`-derived level, the browser entry honoring the same rules, every accepted boolean spelling, warn-and-ignore for each malformed variable, warn-once across three loggers
- **the guard test #60 asked for** — every `LoggerConfig` field must measurably change output. It failed on `metadata` immediately, which is how #67 was found
- `tests/file-transport.test.ts` (new, 11) — lazy fs access, JSON and text output, rotation at `maxsize`, `maxFiles` eviction, archive ordering, a warn-once-naming-the-path failure, per-transport level filtering, one handle across 50 children, console+file fan-out
- `tests/node-logger.test.ts` — the 22 tests built on a `vi.mock('winston')` factory are replaced by 12 that assert behaviour
- `tests/serialization.test.ts` (+12) — repeated siblings, self-reference, indirect cycle, repeated object in an array, cycle and repeat in one payload, repeated `Error`, error + cause sharing an object, `[undefined]` for holes and properties, `Date`, `[MaxDepth]` on 5000-deep nesting, explicit `maxDepth`

The vitest warning about `vi.mock('winston')` not being at top level is gone with the mock.

## Verification

- `publint` — no problems; `attw` — green across all five entry points, both CJS and ESM
- `pnpm test:package` — webpack consumer build compiles
- `pnpm install --frozen-lockfile` — clean; 205 lines of Winston tree removed from `pnpm-lock.yaml`
- `deno publish --dry-run` — 20 files, exactly one `unanalyzable-dynamic-import`, unchanged from before this branch

Pre-existing and untouched: `deno publish` type-checks fail on `src/runtime/browser.ts:79` (`shouldLog` missing an `override` modifier). That predates this branch.

## Docs

- `docs/migration-2.0.md` (new) — six breaking changes, each with before/after output samples
- `README.md` — transports section, file-logging opt-in, the entry-point split, `timestamp`/`colorize` semantics, environment precedence
- `docs/environment-variables.md` — precedence with the config-file link marked pending #58, the new boolean spellings, unrecognized-value behaviour, the browser build-time caveat
- `docs/jsr-winston-import-bug.md` — resolution banner; kept as a record
- `docs/troubleshooting.md`, `docs/webpack-bundler-compatibility.md`, `docs/spec.md`, `docs/tasks.md`, `docs/import-compatibility.md` — Winston references replaced

## Deliberately not in this PR

- Dropping Node 20 (`engines.node` untouched)
- #58 config file loading — needs a product decision, and `createLogger()` being synchronous is the real blocker. The `config.ts` split unblocks the work
- #61 redaction over-matching — needs the tokenization rule written into the Treering spec first
- #66 configuration reference docs — filed so this PR does not grow a documentation rewrite
