### PR TITLE
fix(ci): make the release pipeline safe on maintenance branches

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -7,6 +7,18 @@ on:
       # Maintenance lines: 1.x, 2.x, ... Releases cut from these publish under
       # a channel dist-tag and never claim `latest` on npm.
       - '*.x'
+    paths-ignore:
+      # Neither path can reach a consumer: package.json#files ships dist,
+      # README.md and LICENSE, and deno.json#publish.include ships src,
+      # README.md and LICENSE. A change confined to workflows or to docs/
+      # therefore has nothing to publish, so it should not cut a version.
+      #
+      # This skips a run only when *every* changed file matches, so a PR
+      # touching source alongside docs still releases normally. README.md is
+      # deliberately absent from this list: it is in the published tarball, so
+      # a README-only change does need a release to update the npm page.
+      - '.github/**'
+      - 'docs/**'
 
 permissions:
   contents: write

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -2,7 +2,11 @@ name: Auto Release
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      # Maintenance lines: 1.x, 2.x, ... Releases cut from these publish under
+      # a channel dist-tag and never claim `latest` on npm.
+      - '*.x'
 
 permissions:
   contents: write
@@ -16,6 +20,8 @@ jobs:
     outputs:
       tag: ${{ steps.version.outputs.next }}
       version: ${{ steps.version.outputs.version }}
+      channel: ${{ steps.version.outputs.channel }}
+      is_default: ${{ steps.version.outputs.is_default }}
 
     steps:
       - uses: actions/checkout@v4
@@ -38,14 +44,45 @@ jobs:
       - name: Determine next version
         id: version
         run: |
-          # Use the highest semver tag in the repo, not `git describe`.
-          # `git describe` only sees tags reachable from HEAD, so a reverted
-          # release bump leaves it pointing at an older tag and we recompute a
-          # version that was already published. Filtering on vN.N.N also skips
-          # malformed tags left behind by failed runs.
-          latest_tag=$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -n1)
-          [ -z "$latest_tag" ] && latest_tag="v0.0.0"
+          branch="$GITHUB_REF_NAME"
+          default_branch="${{ github.event.repository.default_branch }}"
+
+          if [ "$branch" = "$default_branch" ]; then
+            # Use the highest semver tag in the repo, not `git describe`.
+            # `git describe` only sees tags reachable from HEAD, so a reverted
+            # release bump leaves it pointing at an older tag and we recompute a
+            # version that was already published. Filtering on vN.N.N also skips
+            # malformed tags left behind by failed runs.
+            latest_tag=$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -n1)
+            [ -z "$latest_tag" ] && latest_tag="v0.0.0"
+            channel="latest"
+            is_default="true"
+          else
+            # A maintenance branch is named `<major>.x`. The repo-wide scan above
+            # is exactly wrong here: with v2.0.0 tagged, a 1.x hotfix would
+            # compute v2.0.1 and overwrite the 2.x line with 1.x code.
+            line="${branch%.x}"
+            case "$line" in
+              ''|*[!0-9]*)
+                echo "::error::Branch '$branch' is neither the default branch nor a <major>.x maintenance branch. Refusing to release." >&2
+                exit 1
+                ;;
+            esac
+
+            latest_tag=$(git tag --list "v${line}.[0-9]*.[0-9]*" --sort=-v:refname | head -n1)
+            if [ -z "$latest_tag" ]; then
+              echo "::error::No v${line}.*.* tag exists. Refusing to guess a starting version for maintenance branch '$branch'." >&2
+              exit 1
+            fi
+
+            channel="v${line}-lts"
+            is_default="false"
+          fi
+
           echo "latest=$latest_tag" >> "$GITHUB_OUTPUT"
+          echo "channel=$channel" >> "$GITHUB_OUTPUT"
+          echo "is_default=$is_default" >> "$GITHUB_OUTPUT"
+          echo "Branch '$branch' -> channel '$channel', starting from $latest_tag"
 
           version="${latest_tag#v}"
           IFS='.' read -r major minor patch <<< "$version"
@@ -57,6 +94,14 @@ jobs:
           # Any conventional-commit type may carry `!`, not just feat/fix/refactor.
           # A `chore!:` used to fall through to a patch bump.
           if echo "$commits" | grep -qE "^[a-zA-Z]+(\(.+\))?!:|^BREAKING[ -]CHANGE:"; then
+            if [ "$is_default" != "true" ]; then
+              # A major bump on a maintenance branch would jump 1.x straight to
+              # 2.0.0 and collide with the live major. If the change really is
+              # breaking it does not belong on this branch; if it is not, drop
+              # the `!` and the BREAKING CHANGE footer.
+              echo "::error::A breaking-change marker was found on maintenance branch '$branch'. Maintenance releases must not bump the major." >&2
+              exit 1
+            fi
             major=$((major + 1))
             minor=0
             patch=0
@@ -109,7 +154,10 @@ jobs:
           git add -A
           git commit -m "chore(release): bump version to v$VERSION"
           git tag -a "$TAG" -m "Release $TAG"
-          git push origin main --follow-tags
+          # Push back to the branch that triggered this run. Hardcoding `main`
+          # fails outright on a maintenance branch, because actions/checkout
+          # never creates a local `main` there.
+          git push origin "HEAD:$GITHUB_REF_NAME" --follow-tags
 
   publish:
     name: Publish Package
@@ -147,11 +195,29 @@ jobs:
       - name: Install latest npm
         run: npm install -g npm@latest
 
-      # Publish to npm with OIDC provenance
+      # Publish to npm with OIDC provenance.
+      # --tag is explicit: without it every publish claims `latest`, so a 1.x
+      # hotfix released after 2.0.0 would silently make the old major the
+      # default install for everyone.
       - name: Publish to npm
-        run: npm publish --provenance --access public
+        run: npm publish --provenance --access public --tag "$NPM_CHANNEL"
+        env:
+          NPM_CHANNEL: ${{ needs.version.outputs.channel }}
 
-      # Publish to JSR
+      # Publish to JSR.
+      # JSR has no dist-tag equivalent and needs none. It computes "latest" as
+      # max(semver) over non-prerelease, non-yanked versions -- publication
+      # timestamp has zero influence -- so a 1.x patch released after 2.0.0
+      # leaves latest at 2.0.0. Range specifiers (jsr:@logan/logger@^1.1.0)
+      # resolve to the highest version satisfying the range, so 1.x consumers
+      # pick up maintenance patches with no channel mechanism at all.
+      #
+      # Confirmed three ways: jsr-io/jsr's own query in
+      # api/src/db/sql_fragments.rs ("version NOT LIKE '%-%' AND is_yanked =
+      # false ORDER BY version DESC LIMIT 1"); jsr-io/jsr#1112, which records
+      # the rationale for not adopting dist-tags; and empirically against
+      # @hono/hono, which reports 4.13.3 as latest while holding twelve 4.9.x
+      # versions -- proving the ordering is semver-aware, not lexicographic.
       - name: Publish to JSR
         run: pnpx jsr publish
 
@@ -174,3 +240,6 @@ jobs:
           generate_release_notes: true
           draft: false
           prerelease: false
+          # A maintenance release must not displace the current major as the
+          # repository's "Latest" release.
+          make_latest: ${{ needs.version.outputs.is_default }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main, dev ]
+    branches: [ main, dev, '*.x' ]
   pull_request:
-    branches: [ main, dev ]
+    branches: [ main, dev, '*.x' ]
 
 jobs:
   test-node:

--- a/docs/maintenance-releases.md
+++ b/docs/maintenance-releases.md
@@ -1,0 +1,115 @@
+# Maintenance releases
+
+How to ship a patch on an older major after a new one has shipped.
+
+## The model
+
+| | Default branch (`main`) | Maintenance branch (`<major>.x`) |
+|---|---|---|
+| Version derived from | highest `vN.N.N` tag in the repo | highest `v<major>.*.*` tag |
+| npm dist-tag | `latest` | `v<major>-lts` |
+| JSR | becomes `latest` | does **not** become latest |
+| GitHub release | marked "Latest" | not marked "Latest" |
+| Major bump | allowed | **refused** |
+
+A maintenance branch is named exactly `<major>.x` — `1.x`, `2.x`. Any other
+non-default branch name is refused by the release workflow rather than guessed
+at.
+
+## Before the first hotfix on a line
+
+**Check the branch is level with its newest tag.** The branch and the tag line
+are two records of "where is 1.x", and they drift the moment a release ships
+from `main` after the branch was cut.
+
+```bash
+git fetch --all --tags
+git merge-base --is-ancestor v1.1.21 origin/1.x && echo "level" || echo "STALE"
+git log --oneline origin/1.x..v1.1.21
+```
+
+If it is stale, fast-forward it before doing anything else:
+
+```bash
+git checkout 1.x && git merge --ff-only v1.1.21 && git push origin 1.x
+```
+
+This matters because the version number is computed from the **tag**, not the
+branch. A branch sitting at `v1.1.20` while `v1.1.21` exists will publish the
+next hotfix as `v1.1.22` — a number that implies it contains everything in
+`v1.1.21`, while the code does not. Anyone on the 1.x line would silently lose
+whatever `v1.1.21` fixed.
+
+## Shipping a hotfix
+
+1. Branch from the maintenance branch, not from `main`:
+   ```bash
+   git checkout 1.x && git pull --ff-only
+   git checkout -b fix/1.x-something
+   ```
+2. Open the PR **against `1.x`**. CI runs there — `ci.yml` includes `*.x` in
+   both its push and pull_request triggers.
+3. Merge. `auto-release.yml` runs on the push to `1.x`, computes the next
+   version from the `v1.*.*` tags only, tags it, and publishes.
+
+### Commit message rules
+
+The version bump is driven by the commit messages in the range since the last
+tag on that line, same as `main`:
+
+- `fix:` / anything else → patch
+- `feat:` → minor
+- `feat!:` or a `BREAKING CHANGE:` footer → **the workflow fails**
+
+That last one is deliberate. A major bump on `1.x` would compute `2.0.0` and
+collide with the live major. If a backport genuinely is breaking it does not
+belong on a maintenance line; if it is not, drop the `!`.
+
+Note that a backport can legitimately be a `feat:` — several of the fixes
+queued for backport (#65, #67) change behaviour enough to warrant a minor rather
+than a patch.
+
+## How consumers get it
+
+**npm** — maintenance releases publish under `v<major>-lts` and never touch
+`latest`:
+
+```bash
+npm install logan-logger@v1-lts     # newest 1.x
+npm install logan-logger            # newest overall, unaffected
+```
+
+Without the explicit `--tag`, `npm publish` assigns `latest` to whatever was
+published most recently, so a 1.x hotfix would silently become the default
+install for every consumer. The workflow always passes `--tag`.
+
+**JSR** — nothing to do. JSR computes `latest` as the highest non-prerelease,
+non-yanked version by semver; publication order has no influence. A range
+specifier resolves to the highest version satisfying it:
+
+```ts
+import { createLogger } from 'jsr:@logan/logger@^1.1.0';  // newest 1.x
+import { createLogger } from 'jsr:@logan/logger';          // newest overall
+```
+
+This is confirmed by JSR's own query (`api/src/db/sql_fragments.rs` in
+`jsr-io/jsr`), by [jsr-io/jsr#1112](https://github.com/jsr-io/jsr/issues/1112)
+recording why dist-tags were not adopted, and observably: `@hono/hono` reports
+`4.13.3` as latest while holding twelve `4.9.x` versions, so the ordering is
+semver-aware rather than lexicographic.
+
+## What is not automated
+
+- **Dependabot** targets the default branch only. A maintenance line does not
+  get dependency PRs, which is usually what you want for a frozen branch.
+- **Backporting** is manual. `git cherry-pick -x <sha>` from `main` keeps a
+  reference to the original commit in the message.
+- **Deciding what deserves a backport.** The bar should be security fixes and
+  correctness bugs, not features.
+
+## Related
+
+- [#62](https://github.com/llbbl/logan-logger-ts/issues/62) — the issue this
+  document closes, with the original analysis of each landmine
+- [`version-management.md`](./version-management.md) — version bumping on `main`
+- [`auto-publishing-setup.md`](./auto-publishing-setup.md) — the publish pipeline


### PR DESCRIPTION
Closes #62.

`auto-release.yml` assumed it only ever ran on `main`. On a `<major>.x` branch it would have mispublished in several separate ways, none of which surface until the first hotfix is attempted — which is the worst possible moment to find them. #65 and #67 are queued for a 1.x backport, so that moment is now.

## Landmines fixed

**Version detection picked the wrong tag.** The repo-wide scan is deliberate on `main` — it fixes #45, where a reverted bump left `git describe` on an unreachable tag. On a maintenance branch the same logic inverts. Detection is now branch-aware: `main` scans every `vN.N.N` tag, a `<major>.x` branch scans only `v<major>.*.*`.

**npm `latest` moved backwards.** `npm publish` with no `--tag` assigns `latest` to whatever was published most recently. A 1.x hotfix after 2.0.0 would have made `npm install logan-logger` serve the old major to everyone, silently. `--tag` is now always explicit: `latest` from the default branch, `v<major>-lts` from a maintenance branch.

**A breaking marker on a maintenance branch would collide.** `feat!:` on `1.x` computes `2.0.0`, which already exists. The run now fails with a message saying so, rather than tripping the tag-collision guard with a confusing error.

**The push-back step was hardcoded to `main`.** `git push origin main --follow-tags` cannot work on a maintenance branch: `actions/checkout` never creates a local `main` there, so the push fails with `src refspec main does not match any` after the tag has already been created locally. Now pushes `HEAD` to the triggering ref.

**GitHub releases would claim "Latest".** `make_latest` is now tied to whether the release came from the default branch.

**No CI on the branch.** `ci.yml` and `auto-release.yml` both trigger on `*.x` now. Dormant branches cost nothing since nothing pushes to them.

## JSR needs no channel

Left unchanged, with the evidence recorded in a comment. JSR computes `latest` as `max(semver)` over non-prerelease, non-yanked versions — publication timestamp has no influence — so a 1.x patch published after 2.0.0 leaves `latest` at 2.0.0. Range specifiers resolve to the highest satisfying version, so `jsr:@logan/logger@^1.1.0` picks up maintenance patches with no tag mechanism at all.

Confirmed three ways rather than taken from the docs:

- JSR's own query in `jsr-io/jsr`, `api/src/db/sql_fragments.rs`: `version NOT LIKE '%-%' AND is_yanked = false ORDER BY version DESC LIMIT 1`
- [jsr-io/jsr#1112](https://github.com/jsr-io/jsr/issues/1112), which records why dist-tags were not adopted
- Empirically: `@hono/hono` reports `4.13.3` as latest while holding twelve `4.9.x` versions, so the ordering is semver-aware rather than lexicographic

## Verification

Ran the new selection logic against the repository's real tags (`v2.0.0`, `v1.1.21`, `v1.1.20`):

```
main + fix:     from=v2.0.0   next=v2.0.1    npm --tag=latest    make_latest=true
main + feat:    from=v2.0.0   next=v2.1.0    npm --tag=latest    make_latest=true
main + feat!:   from=v2.0.0   next=v3.0.0    npm --tag=latest    make_latest=true

1.x + fix:      from=v1.1.21  next=v1.1.22   npm --tag=v1-lts    make_latest=false
1.x + feat:     from=v1.1.21  next=v1.2.0    npm --tag=v1-lts    make_latest=false
1.x + feat!:    REFUSED: breaking marker on maintenance branch

9.x:            REFUSED: no v9.*.* tag
hotfix:         REFUSED: not a <major>.x branch
```

The first 1.x row is the landmine: it produced `v2.0.1` before this change.

`actionlint` reports only the pre-existing SC2129 style nit; `yaml-lint` passes.

## Two things this does not fix

**1. The `1.x` branch is stale, and that is a live problem.** It was cut at `v1.1.20`, but `v1.1.21` shipped from `main` afterwards. Since the version number comes from the *tag* line and the code comes from the *branch*, a hotfix today would publish as `v1.1.22` — a number implying it contains `v1.1.21`, while the code would not. Anyone on 1.x would silently lose the #59 error-serializer fix.

It is a clean fast-forward, zero unique commits on the branch:

```bash
git checkout 1.x && git merge --ff-only v1.1.21 && git push origin 1.x
```

This needs doing before any 1.x work. It is a branch push, not something a PR can carry.

**2. Workflows run from the branch being pushed.** Landing this on `main` does *not* make `1.x` safe — `1.x` still has its own copy of `auto-release.yml`. This change has to be backported to `1.x` as well, and that backport should be the first thing merged there. Until then, pushing to `1.x` triggers nothing at all (its triggers list only `main`), so the branch is inert rather than dangerous.

## Releases are no longer cut for workflow- and docs-only changes

`paths-ignore: ['.github/**', 'docs/**']` on the push trigger. Neither path can reach a consumer — `package.json#files` ships `dist`, `README.md` and `LICENSE`, and `deno.json#publish.include` ships `src`, `README.md` and `LICENSE` — so a change confined to either would have produced a release whose artifact is byte-identical to the one before it.

`paths-ignore` skips a run only when *every* changed file matches, so a PR touching source alongside docs still releases normally. `README.md` is deliberately absent from the list: it ships in the tarball, so a README-only change does still need a release to refresh the npm page.

**This PR is its own first test case.** It touches only `.github/**` and `docs/**`, so merging it will land the change on `main` without cutting `2.0.1`. If a release *does* fire on merge, the filter is wrong and should be reverted.

Same effect on the 1.x backport: pushing the workflow plumbing to `1.x` will not cut a 1.x release either, which is what you want for a branch whose first commit is infrastructure.
