### PR TITLE
fix(ci): backport the maintenance-release pipeline to 1.x

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -7,6 +7,18 @@ on:
       # Maintenance lines: 1.x, 2.x, ... Releases cut from these publish under
       # a channel dist-tag and never claim `latest` on npm.
       - '*.x'
+    paths-ignore:
+      # Neither path can reach a consumer: package.json#files ships dist,
+      # README.md and LICENSE, and deno.json#publish.include ships src,
+      # README.md and LICENSE. A change confined to workflows or to docs/
+      # therefore has nothing to publish, so it should not cut a version.
+      #
+      # This skips a run only when *every* changed file matches, so a PR
+      # touching source alongside docs still releases normally. README.md is
+      # deliberately absent from this list: it is in the published tarball, so
+      # a README-only change does need a release to update the npm page.
+      - '.github/**'
+      - 'docs/**'
 
 permissions:
   contents: write

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -2,7 +2,11 @@ name: Auto Release
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      # Maintenance lines: 1.x, 2.x, ... Releases cut from these publish under
+      # a channel dist-tag and never claim `latest` on npm.
+      - '*.x'
 
 permissions:
   contents: write
@@ -16,6 +20,8 @@ jobs:
     outputs:
       tag: ${{ steps.version.outputs.next }}
       version: ${{ steps.version.outputs.version }}
+      channel: ${{ steps.version.outputs.channel }}
+      is_default: ${{ steps.version.outputs.is_default }}
 
     steps:
       - uses: actions/checkout@v4
@@ -38,14 +44,45 @@ jobs:
       - name: Determine next version
         id: version
         run: |
-          # Use the highest semver tag in the repo, not `git describe`.
-          # `git describe` only sees tags reachable from HEAD, so a reverted
-          # release bump leaves it pointing at an older tag and we recompute a
-          # version that was already published. Filtering on vN.N.N also skips
-          # malformed tags left behind by failed runs.
-          latest_tag=$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -n1)
-          [ -z "$latest_tag" ] && latest_tag="v0.0.0"
+          branch="$GITHUB_REF_NAME"
+          default_branch="${{ github.event.repository.default_branch }}"
+
+          if [ "$branch" = "$default_branch" ]; then
+            # Use the highest semver tag in the repo, not `git describe`.
+            # `git describe` only sees tags reachable from HEAD, so a reverted
+            # release bump leaves it pointing at an older tag and we recompute a
+            # version that was already published. Filtering on vN.N.N also skips
+            # malformed tags left behind by failed runs.
+            latest_tag=$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -n1)
+            [ -z "$latest_tag" ] && latest_tag="v0.0.0"
+            channel="latest"
+            is_default="true"
+          else
+            # A maintenance branch is named `<major>.x`. The repo-wide scan above
+            # is exactly wrong here: with v2.0.0 tagged, a 1.x hotfix would
+            # compute v2.0.1 and overwrite the 2.x line with 1.x code.
+            line="${branch%.x}"
+            case "$line" in
+              ''|*[!0-9]*)
+                echo "::error::Branch '$branch' is neither the default branch nor a <major>.x maintenance branch. Refusing to release." >&2
+                exit 1
+                ;;
+            esac
+
+            latest_tag=$(git tag --list "v${line}.[0-9]*.[0-9]*" --sort=-v:refname | head -n1)
+            if [ -z "$latest_tag" ]; then
+              echo "::error::No v${line}.*.* tag exists. Refusing to guess a starting version for maintenance branch '$branch'." >&2
+              exit 1
+            fi
+
+            channel="v${line}-lts"
+            is_default="false"
+          fi
+
           echo "latest=$latest_tag" >> "$GITHUB_OUTPUT"
+          echo "channel=$channel" >> "$GITHUB_OUTPUT"
+          echo "is_default=$is_default" >> "$GITHUB_OUTPUT"
+          echo "Branch '$branch' -> channel '$channel', starting from $latest_tag"
 
           version="${latest_tag#v}"
           IFS='.' read -r major minor patch <<< "$version"
@@ -57,6 +94,14 @@ jobs:
           # Any conventional-commit type may carry `!`, not just feat/fix/refactor.
           # A `chore!:` used to fall through to a patch bump.
           if echo "$commits" | grep -qE "^[a-zA-Z]+(\(.+\))?!:|^BREAKING[ -]CHANGE:"; then
+            if [ "$is_default" != "true" ]; then
+              # A major bump on a maintenance branch would jump 1.x straight to
+              # 2.0.0 and collide with the live major. If the change really is
+              # breaking it does not belong on this branch; if it is not, drop
+              # the `!` and the BREAKING CHANGE footer.
+              echo "::error::A breaking-change marker was found on maintenance branch '$branch'. Maintenance releases must not bump the major." >&2
+              exit 1
+            fi
             major=$((major + 1))
             minor=0
             patch=0
@@ -109,7 +154,10 @@ jobs:
           git add -A
           git commit -m "chore(release): bump version to v$VERSION"
           git tag -a "$TAG" -m "Release $TAG"
-          git push origin main --follow-tags
+          # Push back to the branch that triggered this run. Hardcoding `main`
+          # fails outright on a maintenance branch, because actions/checkout
+          # never creates a local `main` there.
+          git push origin "HEAD:$GITHUB_REF_NAME" --follow-tags
 
   publish:
     name: Publish Package
@@ -147,11 +195,29 @@ jobs:
       - name: Install latest npm
         run: npm install -g npm@latest
 
-      # Publish to npm with OIDC provenance
+      # Publish to npm with OIDC provenance.
+      # --tag is explicit: without it every publish claims `latest`, so a 1.x
+      # hotfix released after 2.0.0 would silently make the old major the
+      # default install for everyone.
       - name: Publish to npm
-        run: npm publish --provenance --access public
+        run: npm publish --provenance --access public --tag "$NPM_CHANNEL"
+        env:
+          NPM_CHANNEL: ${{ needs.version.outputs.channel }}
 
-      # Publish to JSR
+      # Publish to JSR.
+      # JSR has no dist-tag equivalent and needs none. It computes "latest" as
+      # max(semver) over non-prerelease, non-yanked versions -- publication
+      # timestamp has zero influence -- so a 1.x patch released after 2.0.0
+      # leaves latest at 2.0.0. Range specifiers (jsr:@logan/logger@^1.1.0)
+      # resolve to the highest version satisfying the range, so 1.x consumers
+      # pick up maintenance patches with no channel mechanism at all.
+      #
+      # Confirmed three ways: jsr-io/jsr's own query in
+      # api/src/db/sql_fragments.rs ("version NOT LIKE '%-%' AND is_yanked =
+      # false ORDER BY version DESC LIMIT 1"); jsr-io/jsr#1112, which records
+      # the rationale for not adopting dist-tags; and empirically against
+      # @hono/hono, which reports 4.13.3 as latest while holding twelve 4.9.x
+      # versions -- proving the ordering is semver-aware, not lexicographic.
       - name: Publish to JSR
         run: pnpx jsr publish
 
@@ -174,3 +240,6 @@ jobs:
           generate_release_notes: true
           draft: false
           prerelease: false
+          # A maintenance release must not displace the current major as the
+          # repository's "Latest" release.
+          make_latest: ${{ needs.version.outputs.is_default }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main, dev ]
+    branches: [ main, dev, '*.x' ]
   pull_request:
-    branches: [ main, dev ]
+    branches: [ main, dev, '*.x' ]
 
 jobs:
   test-node:

--- a/docs/maintenance-releases.md
+++ b/docs/maintenance-releases.md
@@ -1,0 +1,115 @@
+# Maintenance releases
+
+How to ship a patch on an older major after a new one has shipped.
+
+## The model
+
+| | Default branch (`main`) | Maintenance branch (`<major>.x`) |
+|---|---|---|
+| Version derived from | highest `vN.N.N` tag in the repo | highest `v<major>.*.*` tag |
+| npm dist-tag | `latest` | `v<major>-lts` |
+| JSR | becomes `latest` | does **not** become latest |
+| GitHub release | marked "Latest" | not marked "Latest" |
+| Major bump | allowed | **refused** |
+
+A maintenance branch is named exactly `<major>.x` — `1.x`, `2.x`. Any other
+non-default branch name is refused by the release workflow rather than guessed
+at.
+
+## Before the first hotfix on a line
+
+**Check the branch is level with its newest tag.** The branch and the tag line
+are two records of "where is 1.x", and they drift the moment a release ships
+from `main` after the branch was cut.
+
+```bash
+git fetch --all --tags
+git merge-base --is-ancestor v1.1.21 origin/1.x && echo "level" || echo "STALE"
+git log --oneline origin/1.x..v1.1.21
+```
+
+If it is stale, fast-forward it before doing anything else:
+
+```bash
+git checkout 1.x && git merge --ff-only v1.1.21 && git push origin 1.x
+```
+
+This matters because the version number is computed from the **tag**, not the
+branch. A branch sitting at `v1.1.20` while `v1.1.21` exists will publish the
+next hotfix as `v1.1.22` — a number that implies it contains everything in
+`v1.1.21`, while the code does not. Anyone on the 1.x line would silently lose
+whatever `v1.1.21` fixed.
+
+## Shipping a hotfix
+
+1. Branch from the maintenance branch, not from `main`:
+   ```bash
+   git checkout 1.x && git pull --ff-only
+   git checkout -b fix/1.x-something
+   ```
+2. Open the PR **against `1.x`**. CI runs there — `ci.yml` includes `*.x` in
+   both its push and pull_request triggers.
+3. Merge. `auto-release.yml` runs on the push to `1.x`, computes the next
+   version from the `v1.*.*` tags only, tags it, and publishes.
+
+### Commit message rules
+
+The version bump is driven by the commit messages in the range since the last
+tag on that line, same as `main`:
+
+- `fix:` / anything else → patch
+- `feat:` → minor
+- `feat!:` or a `BREAKING CHANGE:` footer → **the workflow fails**
+
+That last one is deliberate. A major bump on `1.x` would compute `2.0.0` and
+collide with the live major. If a backport genuinely is breaking it does not
+belong on a maintenance line; if it is not, drop the `!`.
+
+Note that a backport can legitimately be a `feat:` — several of the fixes
+queued for backport (#65, #67) change behaviour enough to warrant a minor rather
+than a patch.
+
+## How consumers get it
+
+**npm** — maintenance releases publish under `v<major>-lts` and never touch
+`latest`:
+
+```bash
+npm install logan-logger@v1-lts     # newest 1.x
+npm install logan-logger            # newest overall, unaffected
+```
+
+Without the explicit `--tag`, `npm publish` assigns `latest` to whatever was
+published most recently, so a 1.x hotfix would silently become the default
+install for every consumer. The workflow always passes `--tag`.
+
+**JSR** — nothing to do. JSR computes `latest` as the highest non-prerelease,
+non-yanked version by semver; publication order has no influence. A range
+specifier resolves to the highest version satisfying it:
+
+```ts
+import { createLogger } from 'jsr:@logan/logger@^1.1.0';  // newest 1.x
+import { createLogger } from 'jsr:@logan/logger';          // newest overall
+```
+
+This is confirmed by JSR's own query (`api/src/db/sql_fragments.rs` in
+`jsr-io/jsr`), by [jsr-io/jsr#1112](https://github.com/jsr-io/jsr/issues/1112)
+recording why dist-tags were not adopted, and observably: `@hono/hono` reports
+`4.13.3` as latest while holding twelve `4.9.x` versions, so the ordering is
+semver-aware rather than lexicographic.
+
+## What is not automated
+
+- **Dependabot** targets the default branch only. A maintenance line does not
+  get dependency PRs, which is usually what you want for a frozen branch.
+- **Backporting** is manual. `git cherry-pick -x <sha>` from `main` keeps a
+  reference to the original commit in the message.
+- **Deciding what deserves a backport.** The bar should be security fixes and
+  correctness bugs, not features.
+
+## Related
+
+- [#62](https://github.com/llbbl/logan-logger-ts/issues/62) — the issue this
+  document closes, with the original analysis of each landmine
+- [`version-management.md`](./version-management.md) — version bumping on `main`
+- [`auto-publishing-setup.md`](./auto-publishing-setup.md) — the publish pipeline


### PR DESCRIPTION
Backport of #68 to the `1.x` maintenance line. Cherry-picks of `624f55a` and `075f169`, applied clean — both workflow files on `1.x` were byte-identical to main's pre-#68 versions.

**Merge this before anything else on `1.x`.**

## Why this has to come first

GitHub Actions runs the workflow file **from the branch being pushed**. Landing #68 on `main` does nothing for this branch — `1.x` keeps its own copy of `auto-release.yml` until this merges. Until then the branch is inert rather than dangerous, because its triggers list only `main`, so pushes here fire no workflow at all.

That cuts both ways: right now `1.x` has no CI either. Any hotfix merged before this would ship unverified, and if the triggers were widened without the rest of #68 it would publish as `v2.0.1` under the `latest` dist-tag.

## What it brings

- **Branch-aware version detection** — scans `v1.*.*` tags only. Without it, the repo-wide scan sees `v2.0.0` and computes `v2.0.1` for a 1.x hotfix.
- **`npm publish --tag v1-lts`** — never claims `latest`. Without it, a 1.x release makes `npm install logan-logger` serve 1.x to everyone.
- **Breaking markers refused** on this branch — `feat!:` here would compute `2.0.0` and collide with the live major.
- **`git push HEAD:$GITHUB_REF_NAME`** instead of a hardcoded `main`, which cannot work here.
- **`make_latest: false`** so a 1.x release does not displace 2.x as the repository's "Latest".
- **CI on `*.x`** — pushes and PRs to this branch now run the full matrix.
- **`paths-ignore`** for `.github/**` and `docs/**`.

Plus `docs/maintenance-releases.md`, so the procedure is readable from this branch too.

## No release from this merge

`paths-ignore` covers every file here, so merging cuts no `1.x` version — which is what you want for a branch whose first commit is infrastructure. That is also the assertion to check: **if a release fires on merge, the filter is wrong.**

Note the ordering wrinkle — the `paths-ignore` arrives in the same merge that widens the triggers, so this merge is the first push to `1.x` that could have released, and it is simultaneously the one that suppresses it. Worth watching the Actions tab.

## Branch state

`1.x` was fast-forwarded from `035ff4b` (v1.1.20) to `da955a3` (v1.1.21) before this branch was cut. It had been stale: the version number comes from the tag line and the code from the branch, so a hotfix would have published as `v1.1.22` while missing the #59 error-serializer fix that shipped in `v1.1.21`.

## What comes after

**#65** and **#67**, both fixed on `main` in #64 and both kept open for this line. Neither is a pure bug fix — environment variables starting to take effect, and `config.metadata` starting to appear, are behaviour changes — so they belong under `feat:` and would land as **`v1.2.0`** on the `v1-lts` channel, not a patch.

Refs #62.
