### PR TITLE
fix(types): add missing override modifiers so deno check passes

### DIFF
--- a/src/runtime/browser.ts
+++ b/src/runtime/browser.ts
@@ -76,7 +76,7 @@ export class BrowserLogger extends BaseLogger {
     return env !== 'production' || this.level <= LogLevel.ERROR;
   }
 
-  protected shouldLog(level: LogLevel): boolean {
+  protected override shouldLog(level: LogLevel): boolean {
     // In browser, respect production environment
     if (!this.shouldLogInProduction() && level < LogLevel.ERROR) {
       return false;

--- a/src/runtime/node.ts
+++ b/src/runtime/node.ts
@@ -136,7 +136,7 @@ export class NodeLogger extends BaseLogger {
     }
   }
 
-  setLevel(level: LogLevel): void {
+  override setLevel(level: LogLevel): void {
     super.setLevel(level);
     if (this.winston) {
       this.winston.level = this.getWinstonLevel(level);


### PR DESCRIPTION
First real release from the `1.x` maintenance line. It fixes a genuine bug and, in doing so, exercises the pipeline that #62 built.

## The bug

`deno check src/index.ts` fails on this branch. Two methods override a `BaseLogger` member without the `override` modifier, and Deno enables `noImplicitOverride`:

```
TS4114: This member must have an 'override' modifier because it overrides a member
        in the base class 'BaseLogger'.
  src/runtime/browser.ts:79   shouldLog
  src/runtime/node.ts:139     setLevel
```

Both genuinely do override (`BaseLogger.shouldLog` at `core/logger.ts:83`, `BaseLogger.setLevel` just above it), so the modifier is a pure type annotation with **zero runtime effect**.

`deno.json` defines a `check` task for exactly this. CI never runs it, and the Deno job that does exist runs `deno test --no-check`, so type errors in the JSR-published source were invisible. Since JSR publishes `src/` rather than a build output, this is the code Deno consumers actually type-check against.

Scoped deliberately to the two `override` keywords. Wiring `deno check` into CI so it cannot regress is a change for `main`, not for a frozen maintenance line.

## Why this is also the pipeline's smoke test

#62's own analysis warned that an untested release path is worse than none. So far the `1.x` pipeline has only been proven *not* to fire — #69 confirmed `paths-ignore` suppresses workflow- and docs-only changes. The positive path has never run.

This PR touches `src/`, so it is not filtered. Merging it should produce the first `v1-lts` release. What to check afterwards:

| | Expected |
|---|---|
| Tag | `v1.1.22` — **not** `v2.0.1` |
| npm `v1-lts` | `1.1.22` (dist-tag created for the first time) |
| npm `latest` | still `2.0.0`, untouched |
| JSR `latest` | still `2.0.0` — 1.1.22 is published but is not the max semver |
| GitHub release | `v1.1.22` present, **not** marked "Latest" |
| `main` | unaffected |

If the tag comes out as `v2.0.1`, or npm `latest` moves to `1.1.22`, the pipeline is wrong and this should be reverted before anything else lands here.

## Verified locally against the 1.x tree

Installed with the 1.x lockfile (`pnpm install --frozen-lockfile`, which pulls winston 3.17.0 as this line still depends on it):

```
vitest      177 passed | 7 skipped
tsc         clean
biome       clean
deno check  0 errors   (was 2)
```

## Commit type

`fix:` → patch → `v1.1.22`. Not `feat:`, and no breaking marker — the release workflow now refuses those on a maintenance branch outright.

Refs #62.
