### PR TITLE
fix(types): add the missing override modifier and run deno check in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,12 @@ jobs:
       - name: Install Deno dependencies (frozen lockfile)
         run: deno install --frozen=true
 
+      # JSR publishes src/ rather than a build output, so this is the source
+      # Deno consumers type-check against. The test step below runs with
+      # --no-check, which is why two TS4114 errors shipped unnoticed.
+      - name: Type check every entry point
+        run: deno task check
+
       - name: Run Deno tests
         run: deno test --no-check --allow-read --allow-env tests/deno-simple.test.ts
 

--- a/deno.json
+++ b/deno.json
@@ -3,14 +3,11 @@
   "version": "2.0.0",
   "exports": "./src/index.ts",
   "compilerOptions": {
-    "allowJs": true,
     "lib": [
       "deno.window",
       "dom"
     ],
-    "strict": true,
-    "sourceMap": false,
-    "inlineSourceMap": false
+    "strict": true
   },
   "test": {
     "include": [
@@ -19,7 +16,7 @@
   },
   "tasks": {
     "test": "deno test --allow-read --allow-env",
-    "check": "deno check src/index.ts"
+    "check": "deno check src/index.ts src/node.ts src/browser.ts src/deno.ts src/bun.ts"
   },
   "publish": {
     "include": [

--- a/src/runtime/browser.ts
+++ b/src/runtime/browser.ts
@@ -76,7 +76,7 @@ export class BrowserLogger extends BaseLogger {
     return env !== 'production' || this.level <= LogLevel.ERROR;
   }
 
-  protected shouldLog(level: LogLevel): boolean {
+  protected override shouldLog(level: LogLevel): boolean {
     // In browser, respect production environment
     if (!this.shouldLogInProduction() && level < LogLevel.ERROR) {
       return false;


### PR DESCRIPTION
The `main`-side half of the fix shipped to `1.x` in #70, plus the CI gate that stops it recurring.

## The bug

`deno check src/index.ts` fails on `main`:

```
TS4114: This member must have an 'override' modifier because it overrides a member
        in the base class 'BaseLogger'.
  src/runtime/browser.ts:79   shouldLog
```

One error here rather than the two on `1.x` — `NodeLogger.setLevel` was the Winston-era override and 2.0 deleted it. `BrowserLogger.shouldLog` genuinely overrides `BaseLogger.shouldLog` (`core/logger.ts:83`), so the modifier is a pure type annotation with **zero runtime effect**.

This matters more than a lint nit because **JSR publishes `src/`, not a build output**. It is the source Deno consumers type-check against, so the error was in the published artifact. `deno publish --dry-run` failed type-checking entirely before this change and passes now.

## Why it went unnoticed

`deno.json` has defined a `check` task since the beginning. CI never ran it, and the Deno job that does exist runs:

```yaml
run: deno test --no-check --allow-read --allow-env tests/deno-simple.test.ts
```

`--no-check`. So the one job named after Deno was structurally incapable of catching a Deno type error.

## Changes

**`src/runtime/browser.ts`** — the `override` keyword.

**`deno.json`** — the `check` task now covers every entry point, not just `index`:

```
deno check src/index.ts src/node.ts src/browser.ts src/deno.ts src/bun.ts
```

All five pass, including `node.ts` with its `node:fs` import. Checking only `index` would have missed anything reachable solely from a runtime entry point, which is precisely where the runtime-specific code lives.

Also dropped `allowJs`, `sourceMap` and `inlineSourceMap` from `compilerOptions`. Deno ignores all three and printed an `Unsupported compiler options` warning on every invocation — noise that would otherwise appear in every CI run now that the task is wired up.

**`.github/workflows/ci.yml`** — runs `deno task check` before the test step.

## Verification

```
deno task check   5 entry points, 0 errors, 0 warnings
deno publish      --dry-run passes with type checking (previously failed)
vitest            238 passed | 7 skipped
tsc               clean
biome             clean
```

## Release behaviour

This touches `src/`, so `paths-ignore` does not suppress it and it will cut **2.0.1**. That is the intended second half of the filter's test: #68 and #69 proved it suppresses workflow- and docs-only changes, and this proves it still lets a real change through. Note the change set mixes `src/`, `deno.json` and `.github/**` — `paths-ignore` skips only when *every* file matches, so a mixed set releases normally, as it should.

`fix(types):` → patch. No breaking marker.

## Not included

Backporting the CI gate to `1.x`. `docs/maintenance-releases.md` sets the bar there at security fixes and correctness bugs, and a CI addition is neither. The `override` fix itself already shipped as `v1.1.22`.
