### PR TITLE
docs: slim the README to a pitch and add a configuration reference

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,134 @@
+# Contributing
+
+## Setup
+
+```bash
+git clone https://github.com/llbbl/logan-logger-ts.git
+cd logan-logger-ts
+pnpm install
+```
+
+`pnpm` is required — the repo pins it via `packageManager`, and `pnpm-workspace.yaml`
+carries supply-chain settings (`minimumReleaseAge`, `blockExoticSubdeps`,
+`strictDepBuilds`) that npm and yarn will not honour. pnpm 11 needs Node ≥ 22.13
+for the toolchain, even though the package itself supports Node 20.19+.
+
+## Commands
+
+```bash
+pnpm test              # vitest, single run
+pnpm test:watch        # watch mode
+pnpm test:coverage
+
+pnpm typecheck         # tsc --noEmit
+pnpm lint              # biome
+pnpm lint:fix
+
+deno task check        # type check all five entry points under Deno
+
+pnpm build             # vite build + declaration generation
+pnpm lint:package      # publint + are-the-types-wrong
+pnpm test:package      # build a real consumer against the packed tarball
+```
+
+`deno task check` matters more than it looks: **JSR publishes `src/`, not a build
+output**, so that is the code Deno consumers type-check against. It runs in CI.
+
+## Architecture
+
+A factory picks a runtime adapter; the adapter writes through transports.
+
+```
+detectRuntime()  ->  LoggerFactory  ->  NodeLogger | BrowserLogger  ->  Transport[]
+```
+
+```
+src/
+├── core/
+│   ├── types.ts        LoggerConfig, LogEntry, ILogger, LogLevel
+│   ├── logger.ts       BaseLogger — level filtering, child context, lazy messages
+│   ├── factory.ts      runtime detection and config assembly
+│   └── transport.ts    Transport interface, registry, ConsoleTransport
+├── runtime/
+│   ├── node.ts         NodeLogger
+│   ├── browser.ts      BrowserLogger, PerformanceLogger, ConsoleGroupLogger
+│   └── file-transport.ts   node:fs — reachable only from the node/bun entries
+├── utils/
+│   ├── config.ts       defaults, environment, merging (no node: specifiers)
+│   ├── config-file.ts  file-based config loading (Node/Deno)
+│   ├── formatting.ts   text and JSON envelopes
+│   ├── runtime.ts      runtime detection and capabilities
+│   └── serialization.ts safeStringify, serializeError, filterSensitiveData
+└── index.ts, node.ts, browser.ts, deno.ts, bun.ts   entry points
+```
+
+Two invariants worth preserving:
+
+- **No `node:` specifier may become reachable from `src/index.ts` or
+  `src/browser.ts`.** The file transport registers itself from the node and bun
+  entry points precisely so the main entry stays bundleable for the browser. If
+  you add anything Node-only, register it the same way. Check with
+  `pnpm build && grep -r "node:" dist/browser.mjs`.
+- **A config field that nothing reads is indistinguishable from a working one.**
+  Four separate fields shipped declared-but-ignored before anyone noticed
+  (#44, #58, #60, #65, #67). `tests/config-environment.test.ts` has a guard test
+  asserting every `LoggerConfig` field measurably changes output — extend it when
+  you add a field.
+
+## Tests
+
+```
+tests/
+├── logger.test.ts, runtime.test.ts, serialization.test.ts   core
+├── factory.test.ts, config.test.ts, config-environment.test.ts
+├── node-logger.test.ts, browser-logger.test.ts, file-transport.test.ts
+└── integration.test.ts
+```
+
+New behaviour needs a test that would fail without it. Prefer asserting on
+observable output over asserting on internals — the Winston-era tests asserted
+against a mock and so passed while the real code path was broken.
+
+## Conformance
+
+This library is the reference implementation of
+[Treering](https://github.com/llbbl/treering), a language-neutral logging spec
+with a JSON conformance suite. Behaviour changes to levels, the record envelope,
+context propagation, serialization or redaction should be checked against it,
+and may need a spec change first.
+
+## Pull requests
+
+1. Branch from `main` (or from `1.x` for a maintenance fix).
+2. Make sure `pnpm test`, `pnpm typecheck`, `pnpm lint` and `deno task check` all pass.
+3. Open the PR. CI runs Node 20.19 / 22.12 / 24, Bun, Deno, a build test and a security scan.
+
+### Commit messages drive releases
+
+Every merge to `main` publishes. The version is computed from the commit
+messages since the last tag:
+
+| Message | Bump |
+|---|---|
+| `fix:`, `chore:`, `docs:`, anything else | patch |
+| `feat:` | minor |
+| any type with `!:`, or a `BREAKING CHANGE:` footer | **major** |
+
+Squash-merge concatenates every commit in the PR, so a marker anywhere in the
+range counts. Simulate before merging:
+
+```bash
+git log "$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -n1)"..HEAD \
+  --pretty=format:"%s%n%b" | grep -nE "^[a-zA-Z]+(\(.+\))?!:|^BREAKING[ -]CHANGE:"
+```
+
+Changes confined to `.github/**` or `docs/**` do not cut a release — neither can
+reach a consumer. Anything touching `src/` or `README.md` does.
+
+Maintenance branches (`<major>.x`) publish under a `v<major>-lts` dist-tag and
+refuse breaking markers outright. See
+[docs/maintenance-releases.md](./docs/maintenance-releases.md).
+
+## License
+
+MIT. By contributing you agree your contributions are licensed under it.

--- a/README.md
+++ b/README.md
@@ -4,441 +4,119 @@
 [![npm](https://img.shields.io/npm/v/logan-logger)](https://www.npmjs.com/package/logan-logger)
 [![JSR](https://jsr.io/badges/@logan/logger)](https://jsr.io/@logan/logger)
 
-A universal TypeScript logging library that works consistently across all JavaScript runtimes: Node.js, Deno, Bun, browsers, and WebAssembly environments.
+One logging API for Node.js, Deno, Bun and the browser. No dependencies.
 
-> **Upgrading from 1.x?** See the [2.0 migration guide](./docs/migration-2.0.md).
+```ts
+import { createLogger, LogLevel } from 'logan-logger';
+
+const logger = createLogger({ level: LogLevel.DEBUG });
+
+logger.info('Application started');
+logger.warn('Config missing', { file: 'config.json' });
+logger.error('Query failed', { err: new Error('timeout') });
+
+// Context that follows every record, without threading it through your code
+const request = logger.child({ requestId: 'req-123' });
+request.info('Processing', { endpoint: '/api/users' });
+
+// Costs nothing when the level filters it out - the function is never called
+logger.debug(() => `Expensive: ${computeHeavyValue()}`);
+```
+
+```
+[2026-08-22T16:31:25.870Z] INFO: Application started
+[2026-08-22T16:31:25.871Z] WARN: Config missing {"file":"config.json"}
+[2026-08-22T16:31:25.872Z] ERROR: Query failed {"err":{"name":"Error","message":"timeout","stack":"..."}}
+[2026-08-22T16:31:25.873Z] INFO: Processing {"requestId":"req-123","endpoint":"/api/users"}
+```
+
+Switch to `format: 'json'` and the same calls emit a structured envelope your log
+aggregator can parse.
+
+## Why this one
+
+- **No dependencies.** Not "few" — `dependencies` and `peerDependencies` are both
+  empty in the published package.
+- **The same code runs everywhere.** One import, one API. The library detects
+  Node, Deno, Bun, the browser or a web worker and picks an implementation.
+- **Browser-safe by construction.** The main entry contains no `node:` specifier
+  at all, so bundling it for the browser cannot fail on an unresolvable built-in.
+  That is enforced by where the code lives, not by a bundler shim.
+- **Serialization that does not lose your data.** Circular references, `Error`
+  objects with their own properties, `BigInt`, `Symbol`, functions and deep
+  nesting all survive — as markers where they must, in full where they can.
+- **TypeScript native**, with correct ESM and CJS types on every entry point.
+
+## Install
+
+```bash
+npm install logan-logger      # or pnpm add / yarn add
+deno add jsr:@logan/logger    # or npx jsr add @logan/logger
+```
+
+Use named imports. There is no default export.
+
+> **Upgrading from 1.x?** See the [migration guide](./docs/migration-2.0.md).
 > Winston is gone, file logging is opt-in, and repeated object references are no
 > longer reported as `[Circular]`.
 
-## Features
+## Runtimes
 
-- 🌐 **Universal Runtime Support** - Works in Node.js, Deno, Bun, browsers, and WebAssembly
-- ⚛️ **Next.js Ready** - Full compatibility with App Router, Server Components, and API Routes
-- 🪶 **Zero Dependencies** - No dependencies at all, required or optional, on any runtime
-- ⚡ **Performance First** - Lazy evaluation, zero-allocation logging, minimal memory footprint
-- 🎯 **TypeScript Native** - Full type safety with comprehensive type definitions
-- 🔧 **Flexible Configuration** - Environment-based auto-configuration or manual setup
-- 🔒 **Safe Serialization** - Handles circular references, Error objects, and sensitive data filtering
-- 🎨 **Rich Browser Support** - Console styling, performance marks, grouping
-- 📊 **Structured Logging** - Rich metadata support with child loggers
-
-## Quick Start
-
-```bash
-# NPM
-npm install logan-logger
-# or
-pnpm add logan-logger
-# or
-yarn add logan-logger
-
-# JSR (Deno/Node.js)
-deno add @logan/logger
-# or
-npx jsr add @logan/logger
-```
-
-### Basic Usage
-
-```typescript
-import { createLogger, LogLevel } from 'logan-logger';
-
-// Create logger with automatic environment configuration
-const logger = createLogger({
-  level: LogLevel.DEBUG,
-  colorize: true
-});
-
-// Basic logging
-logger.info('Application started');
-logger.warn('Configuration missing', { file: 'config.json' });
-logger.error('Database connection failed', { error: new Error('Connection failed') });
-
-// Child loggers with additional context
-const requestLogger = logger.child({ 
-  requestId: 'req-123', 
-  userId: 'user-456' 
-});
-
-requestLogger.info('Processing request', { endpoint: '/api/users' });
-```
-
-Use named imports from `logan-logger` and its runtime subpaths. Default imports
-are not part of the public API.
-
-### Next.js Integration
-
-Logan Logger is fully compatible with Next.js 13+ App Router, including Server Components, Client Components, and API Routes.
-
-#### Server Components
-```typescript
-import { createLogger, LogLevel } from 'logan-logger';
-
-const logger = createLogger({
-  level: process.env.NODE_ENV === 'development' ? LogLevel.DEBUG : LogLevel.INFO,
-  format: 'json'
-});
-
-export default async function ServerComponent() {
-  logger.info('Server component rendered');
-  
-  // Server-side data fetching
-  const data = await fetchData();
-  logger.debug('Data fetched', { recordCount: data.length });
-  
-  return <div>Server content</div>;
-}
-```
-
-#### Client Components
-```typescript
-'use client';
-
-import { createLogger, LogLevel } from 'logan-logger';
-
-const logger = createLogger({
-  level: LogLevel.INFO,
-  colorize: true
-});
-
-export default function ClientComponent() {
-  const handleClick = () => {
-    logger.info('User interaction', { action: 'button_click' });
-  };
-
-  return <button onClick={handleClick}>Click me</button>;
-}
-```
-
-#### API Routes
-```typescript
-// app/api/users/route.ts
-import { NextResponse } from 'next/server';
-import { createLogger } from 'logan-logger';
-
-const logger = createLogger({
-  format: 'json',
-  metadata: { service: 'api' }
-});
-
-export async function GET() {
-  const start = Date.now();
-  logger.info('API request started', { endpoint: '/api/users' });
-  
-  try {
-    const users = await getUsers();
-    const duration = Date.now() - start;
-    
-    logger.info('API request completed', { 
-      statusCode: 200, 
-      duration,
-      userCount: users.length 
-    });
-    
-    return NextResponse.json(users);
-  } catch (error) {
-    const duration = Date.now() - start;
-    logger.error('API request failed', { 
-      statusCode: 500, 
-      duration,
-      error: error instanceof Error ? error.message : 'Unknown error'
-    });
-    
-    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
-  }
-}
-```
-
-> **📋 See [Next.js Compatibility Guide](./docs/nextjs-compatibility.md) for complete setup instructions, advanced patterns, and troubleshooting.**
-
-### Advanced Features
-
-#### Lazy Evaluation for Performance
-```typescript
-// Function is only called if debug level is enabled
-logger.debug(() => `Expensive computation: ${computeHeavyValue()}`);
-```
-
-#### Environment-Based Configuration
-```typescript
-import { createLoggerForEnvironment } from 'logan-logger';
-
-// Automatically configures based on NODE_ENV
-const logger = createLoggerForEnvironment();
-// Production: ERROR level, JSON format
-// Development: DEBUG level, colored console
-// Test: WARN level
-```
-
-#### Runtime-Specific Imports
-
-Logan Logger provides runtime-specific entry points for optimal bundling and type safety:
-
-**🟢 Node.js with file logging:**
-```typescript
-import { createLogger, LogLevel, NodeLogger, createMorganStream } from 'logan-logger/node';
-
-const logger = new NodeLogger({
-  transports: [
-    { type: 'console', options: {} },
-    {
-      type: 'file',
-      level: LogLevel.ERROR,
-      options: { filename: 'logs/error.log', maxsize: 5_242_880, maxFiles: 5 }
-    }
-  ]
-});
-
-// Express/Morgan integration
-app.use(morgan('combined', { stream: createMorganStream(logger) }));
-```
-
-File logging is **opt-in**: with no `transports` configured a logger writes to the
-console and nowhere else, whatever `NODE_ENV` says. The log directory is created
-lazily on the first write, so a logger that is configured but never used touches
-the disk zero times.
-
-The `file` transport is registered by the `logan-logger/node` and
-`logan-logger/bun` entry points. It is deliberately absent from the main
-`logan-logger` entry so that `node:fs` never reaches a browser bundle — configure
-a file transport from the main entry and you get a warning telling you which
-entry point to import instead.
-
-**🌐 Browser-Optimized (Webpack/Vite-Safe):**
-```typescript
-import { createLogger, BrowserLogger, PerformanceLogger } from 'logan-logger/browser';
-
-const logger = new PerformanceLogger();
-
-logger.mark('api-start');
-// ... API call
-logger.measure('api-duration', 'api-start');
-```
-
-**🦕 Deno-Optimized:**
-```typescript
-import { createLogger, BrowserLogger } from 'logan-logger/deno';
-
-const logger = createLogger({ colorize: true });
-logger.info('Deno application started');
-```
-
-**🥟 Bun-Optimized:**
-```typescript
-import { createLogger, NodeLogger } from 'logan-logger/bun';
-
-const logger = createLogger({ level: LogLevel.DEBUG });
-logger.info('Bun application started');
-```
-
-**🔧 Auto-Detection (Generic):**
-```typescript
-import { createLogger } from 'logan-logger';
-
-// Automatically selects appropriate logger based on runtime
-const logger = createLogger();
-```
-
-#### Safe Data Handling
-```typescript
-import { filterSensitiveData } from 'logan-logger';
-
-const userData = {
-  name: 'John Doe',
-  email: 'john@example.com',
-  password: 'secret123',  // Will be filtered
-  apiKey: 'sk_live_...'   // Will be filtered
-};
-
-const safeData = filterSensitiveData(userData);
-logger.info('User processed', safeData);
-// Logs: { name: 'John Doe', email: 'john@example.com', password: '[REDACTED]', apiKey: '[REDACTED]' }
-```
-
-## Runtime Support & Import Paths
-
-| Runtime | Import Path | Status | Implementation | Features |
-|---------|-------------|--------|----------------|----------|
-| **Next.js 13+** | `logan-logger` | ✅ **Full** | **Auto-detection** | **Server/Client Components, API Routes, Edge Runtime** |
-| Node.js 20+ | `logan-logger/node` | ✅ Full | Console + File transports | File logging with size rotation, custom transports, Morgan integration |
-| Bun | `logan-logger/bun` | ✅ Full | NodeLogger adapter | Same as Node.js |
-| Browser | `logan-logger/browser` | ✅ Full | Console API | CSS styling, performance marks, grouping |
-| Deno | `@logan/logger/deno` (JSR) | ✅ Basic | BrowserLogger adapter | Console logging (native implementation planned) |
-| WebWorker | `logan-logger/browser` | ✅ Basic | Console adapter | Basic console logging |
-| Auto-detect | `logan-logger` | ✅ Basic | Runtime detection | Automatic adapter selection |
-
-## Configuration
-
-### Log Levels
-```typescript
-enum LogLevel {
-  DEBUG = 0,    // Most verbose
-  INFO = 1,     // General information  
-  WARN = 2,     // Warning messages
-  ERROR = 3,    // Error messages
-  SILENT = 4    // No output
-}
-```
-
-### Environment Variables
-```bash
-LOG_LEVEL=debug      # debug, info, warn, error, silent
-LOG_FORMAT=json      # json, text
-LOG_TIMESTAMP=true   # true/1/yes/on, false/0/no/off
-LOG_COLOR=false      # true/1/yes/on, false/0/no/off
-```
-
-These sit at the **top** of the precedence chain — above configuration passed to
-`createLogger()` — so an operator can change logging on a running service without
-a deploy. Opt out with `createLogger({ ..., ignoreEnvironment: true })`. A value
-that does not parse is ignored with a warning rather than silently resolving to a
-default.
-
-> **📋 See [Environment Variables Documentation](./docs/environment-variables.md) for complete details, examples, and runtime-specific considerations.**
-
-### Configuration Options
-```typescript
-interface LoggerConfig {
-  level: LogLevel;
-  format: 'json' | 'text' | 'custom';
-  timestamp: boolean;
-  colorize: boolean;
-  metadata: Record<string, any>;
-  transports?: TransportConfig[];
-}
-```
-
-`timestamp` and `colorize` apply to the **text** form only. The JSON envelope
-always carries a timestamp and is never colorized, so a structured log stream
-stays parseable. `colorize` additionally defers to the terminal: ANSI escapes are
-suppressed when stdout is not a TTY, and the `NO_COLOR` / `FORCE_COLOR`
-conventions are honored.
-
-### Transports
-
-`transports` lists exactly where records go, in order. Omit it and you get the
-console alone.
-
-```typescript
-import { LogLevel, NodeLogger } from 'logan-logger/node';
-
-const logger = new NodeLogger({
-  transports: [
-    { type: 'console', options: { format: 'text', colorize: true } },
-    { type: 'file', level: LogLevel.ERROR, options: { filename: 'logs/error.log' } }
-  ]
-});
-```
-
-| Type | Available from | Options |
+| Runtime | Import | Notes |
 |---|---|---|
-| `console` | everywhere | `format`, `timestamp`, `colorize` |
-| `file` | `logan-logger/node`, `logan-logger/bun` | `filename`, `maxsize`, `maxFiles`, `format`, `timestamp` |
-| `custom` | everywhere | `transport` — any object with a `write(entry)` method |
+| Auto-detect | `logan-logger` | Also the right choice for Next.js and other isomorphic frameworks |
+| Node.js 20+ | `logan-logger/node` | Adds the file transport and Morgan integration |
+| Bun | `logan-logger/bun` | Same as Node |
+| Browser / WebWorker | `logan-logger/browser` | CSS-styled console, performance marks, grouping |
+| Deno | `jsr:@logan/logger` | Console; native implementation planned |
 
-Each transport is constructed behind its own guard: one failing to initialize
-warns and is dropped, and the rest keep working. The same applies at write time.
+Details and examples: [docs/runtimes.md](./docs/runtimes.md).
 
-A child logger **shares** its parent's transport instances, so
-`logger.child({ requestId })` per request costs no extra file handles.
+## Configuring
 
-Plug in your own destination either inline:
-
-```typescript
-const logger = new NodeLogger({
-  transports: [{ type: 'custom', options: { transport: { type: 'syslog', write(entry) { /* … */ } } } }]
+```ts
+createLogger({
+  level: LogLevel.INFO,
+  format: 'json',                    // or 'text'
+  timestamp: true,                   // text form only
+  colorize: false,                   // text form only, and only on a TTY
+  metadata: { service: 'api' },      // attached to every record
+  transports: [                      // omit for console only
+    { type: 'console', options: {} },
+    { type: 'file', level: LogLevel.ERROR, options: { filename: 'logs/error.log' } },
+  ],
 });
 ```
 
-or by name, so it can be selected from configuration:
+`LOG_LEVEL`, `LOG_FORMAT`, `LOG_TIMESTAMP` and `LOG_COLOR` override this at
+runtime, so an operator can turn up verbosity without a deploy. Libraries that
+need to pin their own logging set `ignoreEnvironment: true`.
 
-```typescript
-import { registerTransport } from 'logan-logger';
+Every field, every transport option, and the serialization rules:
+[docs/configuration.md](./docs/configuration.md).
 
-registerTransport('syslog', (config, context) => new SyslogTransport(config.options));
-```
+## Documentation
 
-## API Reference
+[**Full documentation index**](./docs/README.md)
 
-### Core Methods
-```typescript
-interface ILogger {
-  debug(message: string | (() => string), metadata?: any): void;
-  info(message: string | (() => string), metadata?: any): void;
-  warn(message: string | (() => string), metadata?: any): void;
-  error(message: string | (() => string), metadata?: any): void;
-  
-  setLevel(level: LogLevel): void;
-  getLevel(): LogLevel;
-  child(metadata: Record<string, any>): ILogger;
-}
-```
+- [Configuration reference](./docs/configuration.md)
+- [Runtimes and entry points](./docs/runtimes.md)
+- [Environment variables](./docs/environment-variables.md)
+- [Next.js](./docs/nextjs-compatibility.md) · [Bundlers](./docs/webpack-bundler-compatibility.md)
+- [Troubleshooting](./docs/troubleshooting.md)
+- [Migrating from 1.x](./docs/migration-2.0.md)
 
-### Factory Functions
-```typescript
-// Create logger with explicit configuration
-createLogger(config?: Partial<LoggerConfig>): ILogger;
-
-// Create logger based on environment
-createLoggerForEnvironment(): ILogger;
-```
-
-## Development
-
-### Setup
-```bash
-git clone <repository>
-cd logan-logger-ts
-pnpm install
-```
-
-### Commands
-```bash
-# Development
-pnpm dev                    # Run with bun
-pnpm test                   # Test watch mode
-pnpm test:run              # Single test run
-pnpm test:ui               # Test UI
-
-# Building
-pnpm build                 # Full build
-pnpm typecheck            # Type checking
-pnpm lint                  # Code linting
-
-# Specific tests
-vitest run tests/logger.test.ts
-```
-
-## Architecture
-
-Logan Logger uses a **Factory + Adapter pattern**:
-
-1. **Runtime Detection** - Automatically detects the current JavaScript environment
-2. **Factory Creation** - Creates the appropriate logger implementation
-3. **Runtime Adapters** - Optimized implementations for each environment
-4. **Unified Interface** - Consistent API across all runtimes
-
-### File Structure
-```
-src/
-├── core/           # Core interfaces and factory
-├── runtime/        # Runtime-specific implementations  
-├── utils/          # Utilities (serialization, config, runtime detection)
-└── index.ts        # Main exports
-```
+API documentation is generated from source on [JSR](https://jsr.io/@logan/logger/doc).
 
 ## Contributing
 
-1. Fork the repository
-2. Create a feature branch
-3. Add tests for new functionality
-4. Ensure all tests pass: `pnpm test:run`
-5. Submit a pull request
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for setup, architecture and the release
+process.
+
+This library is the reference implementation of
+[Treering](https://github.com/llbbl/treering), a language-neutral logging
+specification with a conformance suite.
 
 ## License
 
-MIT License - see LICENSE file for details.
-
-## Credits
-
-Created by Logan Lindquist Land
+MIT © Logan Lindquist Land

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,42 @@
+# Documentation
+
+## Using the library
+
+| | |
+|---|---|
+| [configuration.md](./configuration.md) | Every `LoggerConfig` field, transports, serialization, redaction |
+| [runtimes.md](./runtimes.md) | Entry points and per-runtime behaviour |
+| [environment-variables.md](./environment-variables.md) | `LOG_LEVEL`, `LOG_FORMAT`, `LOG_TIMESTAMP`, `LOG_COLOR` |
+| [migration-2.0.md](./migration-2.0.md) | Upgrading from 1.x |
+| [troubleshooting.md](./troubleshooting.md) | Common errors and their causes |
+
+## Integration
+
+| | |
+|---|---|
+| [nextjs-compatibility.md](./nextjs-compatibility.md) | App Router, Server and Client Components, Edge |
+| [webpack-bundler-compatibility.md](./webpack-bundler-compatibility.md) | Webpack, Vite, Rollup, esbuild, Parcel |
+| [import-compatibility.md](./import-compatibility.md) | ESM/CJS interop and named imports |
+
+## Maintaining the project
+
+| | |
+|---|---|
+| [maintenance-releases.md](./maintenance-releases.md) | Shipping a patch on an older major |
+| [version-management.md](./version-management.md) | Version bumping on `main` |
+| [auto-publishing-setup.md](./auto-publishing-setup.md) | How the publish pipeline is wired |
+| [git-worktrees.md](./git-worktrees.md) | Working on several branches at once |
+
+## Design
+
+| | |
+|---|---|
+| [spec.md](./spec.md) | Architecture and design goals |
+| [tasks.md](./tasks.md) | Development roadmap |
+| [Treering](https://github.com/llbbl/treering) | The cross-language logging spec this library implements |
+
+## Historical
+
+| | |
+|---|---|
+| [jsr-winston-import-bug.md](./jsr-winston-import-bug.md) | Resolved in 2.0; kept as a record of the failure mode |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,392 @@
+# Configuration reference
+
+Every field of `LoggerConfig`: what it changes, where it applies, how its default
+is resolved, and what overrides it.
+
+```ts
+interface LoggerConfig {
+  level: LogLevel;
+  format: 'json' | 'text' | 'custom';
+  timestamp: boolean;
+  colorize: boolean;
+  metadata: Record<string, any>;
+  transports?: TransportConfig[];
+  ignoreEnvironment?: boolean;
+}
+```
+
+Every example below is real output, captured from the library rather than
+written by hand.
+
+---
+
+## Precedence
+
+Highest wins:
+
+```
+library defaults  <  explicit config  <  environment variables
+```
+
+Environment variables sit on top so an operator can change logging on a running
+service without a deploy. A library that must pin its own logging regardless of
+the host application's environment sets [`ignoreEnvironment`](#ignoreenvironment).
+
+**Config files are not in this chain.** `loadConfigFromFile()` is exported and
+usable directly, but `createLogger()` is synchronous and cannot await it — see
+[#58](https://github.com/llbbl/logan-logger-ts/issues/58).
+
+---
+
+## `level`
+
+Minimum severity to emit. Anything below it is discarded before the message is
+resolved, so a [lazy message](#lazy-messages) costs nothing when filtered.
+
+```ts
+enum LogLevel {
+  DEBUG = 0,   // most verbose
+  INFO = 1,
+  WARN = 2,
+  ERROR = 3,
+  SILENT = 4,  // a threshold, not a level anything is logged at
+}
+```
+
+`SILENT` exists only as a filter value. No call emits at it; setting
+`level: LogLevel.SILENT` discards everything.
+
+**Default** `INFO`, or derived from the environment when you use
+`createLoggerForEnvironment()`:
+
+| `NODE_ENV` | Level |
+|---|---|
+| `production` | `ERROR` |
+| `staging`, `test` | `WARN` |
+| `development`, `dev` | `DEBUG` |
+| anything else | `INFO` |
+
+**Overridden by** `LOG_LEVEL`. Changeable at runtime with `logger.setLevel()`.
+
+---
+
+## `format`
+
+Selects the record shape. `'custom'` is accepted by the type and currently
+behaves as `'text'`.
+
+```
+format: 'text'   [2026-08-22T16:31:25.870Z] INFO: User logged in {"userId":123}
+format: 'json'   {"timestamp":"2026-08-22T16:31:25.870Z","level":"info","message":"User logged in","runtime":"node","metadata":{"userId":123}}
+```
+
+Two asymmetries are deliberate:
+
+- **Text uppercases the level, JSON lowercases it.**
+- **JSON nests metadata** under a `metadata` key rather than spreading it at the
+  top level, so a field called `level` or `message` in your metadata cannot
+  collide with the envelope.
+
+JSON omits `metadata` entirely when there is none, rather than emitting `null`
+or `{}`.
+
+**Default** `'text'`. **Overridden by** `LOG_FORMAT`.
+
+---
+
+## `timestamp`
+
+Whether the **text** form carries a timestamp.
+
+```
+timestamp: true    [2026-08-22T16:31:25.870Z] INFO: User logged in {"userId":123}
+timestamp: false   INFO: User logged in {"userId":123}
+```
+
+**It does not affect JSON.** The structured envelope always carries a
+timestamp — a record without one is not much use to a log aggregator, and
+omitting it would make the envelope shape conditional.
+
+Set it to `false` when something downstream already stamps each line: systemd,
+Docker's log driver, and most hosted log collectors all do.
+
+**Default** `true`. **Overridden by** `LOG_TIMESTAMP`.
+
+---
+
+## `colorize`
+
+ANSI colour on the level token in the **text** form. Nothing else in the line is
+coloured, and the JSON form is never coloured at all.
+
+```
+colorize: false   [2026-08-22T16:31:25.870Z] INFO: User logged in
+colorize: true    [2026-08-22T16:31:25.870Z] \x1b[32mINFO\x1b[0m: User logged in
+```
+
+`\x1b[32m` starts green, `\x1b[0m` resets. Per level: DEBUG cyan, INFO green,
+WARN yellow, ERROR red. In the browser the same setting applies CSS through the
+console's `%c` mechanism instead — `color: #dc3545; font-weight: bold` for
+errors — since terminals and devtools have no shared colour mechanism.
+
+**The default is not simply "on".** `capabilities.colorSupport` says whether the
+runtime *can* colourize; the default additionally asks whether it *should*:
+
+1. runtime cannot colourize → `false`
+2. no `process` object, i.e. a browser → `true`; the console styles its own output and there is no stream to pollute
+3. `NO_COLOR` set to any non-empty value → `false`
+4. `FORCE_COLOR` set → `true` unless the value is exactly `"0"`
+5. otherwise → whether `process.stdout` is a TTY
+
+That gate matters more than the feature. Escape bytes written into a redirected
+file or a log shipper break grep patterns and render as literal `[32m` in most
+log UIs. This is why `colorize` is usually the wrong thing to force on in
+production.
+
+Note the gate resolves the **default only**. An explicit `colorize: true` still
+wins over a non-TTY stdout.
+
+**Default** as resolved above. **Overridden by** `LOG_COLOR`.
+
+---
+
+## `metadata`
+
+Default metadata merged into every record the logger emits, and inherited by its
+children.
+
+```ts
+createLogger({ metadata: { service: 'api' } }).info('User logged in', { userId: 123 });
+// [2026-08-22T16:31:25.871Z] INFO: User logged in {"service":"api","userId":123}
+```
+
+Merging is **shallow**, and call-site metadata wins on a key collision:
+
+```ts
+const logger = createLogger({ metadata: { stage: 'default' } });
+logger.info('x', { stage: 'override' });   // {"stage":"override"}
+```
+
+A nested object is replaced wholesale rather than deep-merged. `{ ctx: {a:1,b:2} }`
+overridden by `{ ctx: {b:3} }` yields `{ ctx: {b:3} }`, not `{ ctx: {a:1,b:3} }`.
+
+Use it for values constant across the process — service name, version, region,
+instance id — and `logger.child()` for values constant across a unit of work.
+
+**Default** `{}`. Not settable from the environment.
+
+---
+
+## `transports`
+
+Where records go, in order. See [Transports in detail](#transports-in-detail) below.
+
+**Default** a single console transport. Omitting the field entirely gives the
+same result.
+
+---
+
+## `ignoreEnvironment`
+
+Opts out of `LOG_LEVEL`, `LOG_FORMAT`, `LOG_TIMESTAMP` and `LOG_COLOR`.
+
+```ts
+createLogger({ level: LogLevel.WARN, ignoreEnvironment: true });
+```
+
+Environment-as-override is right for an application, and wrong for a library: a
+host process that exports `LOG_LEVEL=debug` for its own logger would otherwise
+turn on debug output for every dependency using logan-logger. If you are
+shipping a library, set this.
+
+**Default** `false`.
+
+---
+
+## Environment variables
+
+| Variable | Accepts |
+|---|---|
+| `LOG_LEVEL` | `debug`, `info`, `warn`, `warning`, `error`, `silent`, `none` |
+| `LOG_FORMAT` | `json`, `text` |
+| `LOG_TIMESTAMP` | `true`/`1`/`yes`/`on`, `false`/`0`/`no`/`off` |
+| `LOG_COLOR` | as above |
+
+Case-insensitive, whitespace trimmed. **A value that does not parse is ignored
+with a one-time warning**, falling through to the next configuration source
+rather than resolving to a default — `LOG_LEVEL=verbose` does not silently
+become `info`.
+
+In a browser these exist only if your bundler inlined them at build time, and
+bundlers only inline their own prefixed names by default. Map them explicitly
+(Vite's `define`, for instance) if you want them.
+
+Full detail in [environment-variables.md](./environment-variables.md).
+
+---
+
+## Transports in detail
+
+A transport is anything with a `write(entry)` method. `LoggerConfig.transports`
+lists them in order; omit it and you get the console alone.
+
+```ts
+import { LogLevel, NodeLogger } from 'logan-logger/node';
+
+const logger = new NodeLogger({
+  transports: [
+    { type: 'console', options: { format: 'text', colorize: true } },
+    { type: 'file', level: LogLevel.ERROR, options: { filename: 'logs/error.log' } },
+  ],
+});
+```
+
+| Type | Available from | Options |
+|---|---|---|
+| `console` | everywhere | `format`, `timestamp`, `colorize` |
+| `file` | `logan-logger/node`, `logan-logger/bun` | `filename`, `maxsize`, `maxFiles`, `format`, `timestamp` |
+| `custom` | everywhere | `transport` — any object with `write(entry)` |
+
+`TransportConfig.level` filters per destination, independently of the logger's
+own level. The example above sends everything to the console and only errors to
+the file.
+
+### Guarantees
+
+- **Each transport is guarded independently.** One that throws while being
+  constructed warns and is dropped; the rest are still built. The same applies
+  at write time, so a broken destination cannot silence a working one.
+- **Child loggers share transport instances.** `logger.child({ requestId })` per
+  request opens no additional file handles.
+- **Transport options override the logger's presentation settings**, so a
+  console transport can be `text` while a file transport is `json`.
+
+### The file transport
+
+Node and Bun only, and **opt-in** — file logging is never implied by `NODE_ENV`.
+
+```ts
+{ type: 'file', options: { filename: 'logs/app.log', maxsize: 5_242_880, maxFiles: 5 } }
+```
+
+| Option | Default | |
+|---|---|---|
+| `filename` | required | Relative paths resolve against `process.cwd()` |
+| `maxsize` | `5242880` (5 MiB) | `0` disables rotation |
+| `maxFiles` | `5` | Archives kept as `app.log.1` … `app.log.N`, newest first |
+| `format` | `'json'` | Deliberately **not** inherited from the logger — files are read by machines |
+| `timestamp` | inherited | |
+
+Behaviour worth knowing:
+
+- **The directory and file handle are created lazily, on first write.** A logger
+  that is configured but never writes touches the disk zero times, which is what
+  makes a file transport safe to declare in a read-only container.
+- **Writes are synchronous** `writeSync` calls against a held descriptor. One
+  syscall per line, and nothing sits in a userland buffer waiting to be lost at
+  exit.
+- **Failures warn once and never throw.** A logging destination going away must
+  not take the application with it, nor spam the console on every line after.
+- The warning names the resolved absolute path and the underlying syscall.
+
+It is registered by the `logan-logger/node` and `logan-logger/bun` entry points,
+not by the main entry. That separation is what keeps `node:fs` out of browser
+bundles. Configure a `file` transport from `logan-logger` and you get a warning
+naming the entry point to import instead.
+
+### Custom transports
+
+Inline:
+
+```ts
+const logger = new NodeLogger({
+  transports: [{
+    type: 'custom',
+    options: { transport: { type: 'syslog', write(entry) { /* … */ } } },
+  }],
+});
+```
+
+Or registered by name, so it can be selected from configuration:
+
+```ts
+import { registerTransport } from 'logan-logger';
+
+registerTransport('syslog', (config, context) => new SyslogTransport(config.options));
+```
+
+`entry` is a `LogEntry`: `{ timestamp: Date, level: LogLevel, message: string,
+metadata?: Record<string, any>, runtime: RuntimeName }`. Use `formatLogEntry`
+from the package if you want the standard text or JSON shape.
+
+---
+
+## Lazy messages
+
+A message can be a function, evaluated only if the record survives the level
+filter:
+
+```ts
+logger.debug(() => `Expensive: ${computeHeavyValue()}`);
+```
+
+Below the threshold the function is never called. Above it, exactly once.
+
+---
+
+## Serialization
+
+Metadata is serialized with `safeStringify`, which substitutes what JSON cannot
+represent:
+
+| Value | Rendered |
+|---|---|
+| `undefined` | `"[undefined]"` |
+| `function foo(){}` | `"[Function: foo]"` |
+| an anonymous function | `"[Function: anonymous]"` |
+| `123n` | `"[BigInt: 123]"` |
+| `Symbol('x')` | `"[Symbol: Symbol(x)]"` |
+| a genuine cycle | `"[Circular]"` |
+| deeper than 100 levels | `"[MaxDepth]"` |
+| `Error` | `{ name, message, stack, ...own properties }` |
+| `Date` and anything with `toJSON` | its `toJSON()` result |
+
+**`[Circular]` means a genuine cycle** — a value that is its own ancestor. The
+same object referenced twice as siblings is a DAG, not a cycle, and serializes
+in full at each occurrence. (Before 2.0 it did not; see the
+[migration guide](./migration-2.0.md).)
+
+Errors include **all own properties**, enumerable or not, in the order
+`name, message, stack, rest`. `stack` is omitted when undefined, an accessor
+that throws yields `"[Throws]"`, and an ES2022 `cause` is followed.
+
+### Redaction
+
+Redaction is never automatic. Apply it yourself:
+
+```ts
+import { filterSensitiveData } from 'logan-logger';
+
+logger.info('User processed', filterSensitiveData({
+  name: 'John Doe',
+  password: 'secret123',   // -> "[REDACTED]"
+  apiKey: 'sk_live_...',   // -> "[REDACTED]"
+}));
+```
+
+Default keys: `password`, `token`, `secret`, `key`, `auth`. Matching is
+case-insensitive and recurses into nested objects and arrays. Passing your own
+list **replaces** the defaults rather than extending them.
+
+> **Matching is by substring, so it over-matches.** `monkey`, `keyboard` and
+> `tokenizer` are all redacted today because they contain `key` or `token`.
+> Tracked in [#61](https://github.com/llbbl/logan-logger-ts/issues/61).
+
+---
+
+## Related
+
+- [environment-variables.md](./environment-variables.md) — the variables in full
+- [runtimes.md](./runtimes.md) — entry points and per-runtime behaviour
+- [migration-2.0.md](./migration-2.0.md) — what changed in 2.0
+- [troubleshooting.md](./troubleshooting.md)

--- a/docs/runtimes.md
+++ b/docs/runtimes.md
@@ -1,0 +1,130 @@
+# Runtimes and entry points
+
+The main entry detects the runtime and picks an implementation for you. The
+subpath entries skip the detection, which gives a smaller bundle and a type
+surface that reflects what is actually available there.
+
+| Runtime | Import | Implementation | Notes |
+|---|---|---|---|
+| Auto-detect | `logan-logger` | picked at runtime | Safe in a browser bundle; no `node:` specifier |
+| Next.js 13+ | `logan-logger` | picked at runtime | Server and Client Components, API Routes, Edge |
+| Node.js 20+ | `logan-logger/node` | `NodeLogger` | File transport, Morgan integration |
+| Bun | `logan-logger/bun` | `NodeLogger` | Same as Node |
+| Browser | `logan-logger/browser` | `BrowserLogger` | CSS styling, performance marks, grouping |
+| Deno | `jsr:@logan/logger` | `BrowserLogger` | Console only; native implementation planned |
+| WebWorker | `logan-logger/browser` | `BrowserLogger` | Console only |
+
+Use named imports throughout. **There is no default export** on any entry point.
+
+---
+
+## Node.js
+
+```ts
+import { createLogger, LogLevel, NodeLogger, createMorganStream } from 'logan-logger/node';
+
+const logger = new NodeLogger({
+  transports: [
+    { type: 'console', options: {} },
+    {
+      type: 'file',
+      level: LogLevel.ERROR,
+      options: { filename: 'logs/error.log', maxsize: 5_242_880, maxFiles: 5 },
+    },
+  ],
+});
+
+// Express / Morgan
+app.use(morgan('combined', { stream: createMorganStream(logger) }));
+```
+
+This entry point is what registers the `file` transport — see
+[configuration.md](./configuration.md#the-file-transport) for its options and
+guarantees. File logging is opt-in and never implied by `NODE_ENV`.
+
+`NodeLogger` also exposes `getTransports()` and `close()`, the latter releasing
+every transport's resources.
+
+## Browser
+
+```ts
+import { createLogger, BrowserLogger, PerformanceLogger } from 'logan-logger/browser';
+
+const logger = new PerformanceLogger();
+logger.mark('api-start');
+// ... work
+logger.measure('api-duration', 'api-start');
+```
+
+Also exports `ConsoleGroupLogger` for grouped output. `colorize` here applies CSS
+through the console's `%c` mechanism rather than ANSI.
+
+## Deno
+
+```ts
+import { createLogger } from 'jsr:@logan/logger';
+
+createLogger({ colorize: true }).info('Deno application started');
+```
+
+JSR publishes `src/` rather than a build output, so Deno consumers type-check
+against the library's actual source. `deno task check` runs in CI to keep that
+honest.
+
+## Bun
+
+```ts
+import { createLogger, LogLevel, NodeLogger } from 'logan-logger/bun';
+
+createLogger({ level: LogLevel.DEBUG }).info('Bun application started');
+```
+
+Bun implements `node:fs`, so the file transport works exactly as it does on Node.
+
+---
+
+## Why the main entry stays browser-safe
+
+`node:fs` is imported statically by the file transport, which is reachable only
+from `logan-logger/node` and `logan-logger/bun`. Those entry points are what
+register the `file` transport with the shared registry.
+
+The consequence is a genuinely universal main entry: `dist/browser.mjs` and the
+chunks reachable from `dist/index.mjs` contain **no `node:` specifier at all**,
+so bundling `logan-logger` for the browser cannot fail on an unresolvable
+built-in. That matters most for isomorphic frameworks, where the same import
+gets bundled for both sides.
+
+The trade-off is explicit: configure a `file` transport from the main entry and
+you get a warning naming the entry point to import instead, rather than silent
+failure.
+
+---
+
+## Next.js
+
+Works in Server Components, Client Components, API Routes and the Edge runtime
+from the single `logan-logger` import.
+
+```ts
+// app/api/users/route.ts
+import { createLogger } from 'logan-logger';
+
+const logger = createLogger({ format: 'json', metadata: { service: 'api' } });
+
+export async function GET() {
+  logger.info('API request started', { endpoint: '/api/users' });
+  // ...
+}
+```
+
+Full setup, advanced patterns and troubleshooting:
+[nextjs-compatibility.md](./nextjs-compatibility.md).
+
+## Bundlers
+
+Webpack, Vite, Rollup, esbuild and Parcel all work without configuration. If you
+are externalising anything, externalise `node:*` rather than naming packages —
+there are no dependencies to externalise.
+[webpack-bundler-compatibility.md](./webpack-bundler-compatibility.md) has
+per-bundler configuration.


### PR DESCRIPTION
Closes #66.

## The problem

`README.md` was **444 lines**, and `## Quick Start` alone was **233 of them** — over half the file under a heading that promises brevity. A reader deciding whether to use the library at all had to pass five per-runtime import examples, a transports table, three Next.js code samples and an environment-variable reference before reaching "Runtime Support".

Meanwhile `docs/` already held 2,941 lines covering most of the same ground. The README duplicated a slice of it, and the duplicated slice is the half most likely to drift.

## After

**README: 444 → 122 lines** (13,598 → 4,855 bytes).

The new structure is a pitch, not a manual: one-sentence description, a single fifteen-line example showing a logger, a child logger and lazy evaluation with its real output underneath, four reasons to choose it, install, a runtime table, a configuration sketch, and links out.

The three strongest selling points were previously buried or unstated, and now lead:

- **No dependencies** — as of 2.0 literally true, `dependencies` and `peerDependencies` both empty in the published tarball. It was the third of nine bullets.
- **Browser-safe by construction** — `dist/browser.mjs` and everything reachable from `dist/index.mjs` contain no `node:` specifier. Stated nowhere before, and it is the real differentiator against every Node-first logger.
- **Serialization that does not lose data** — was a generic "safe serialization" bullet.

## New documents

**`docs/configuration.md`** — the reference #66 was originally about. One section per `LoggerConfig` field, each covering what it changes, which output forms it applies to, how its default resolves, and what overrides it. Plus transports, lazy messages, serialization and redaction.

It documents the six rules governing `colorize` that existed nowhere: ignored under `format: 'json'`, gated on TTY, `NO_COLOR`/`FORCE_COLOR`, derived from `capabilities.colorSupport`, overridden to `false` under `NODE_ENV=production`, and build-time only in browsers. Same for the `timestamp` text/JSON asymmetry, the shallow `metadata` merge, `format: 'custom'` behaving as `'text'`, and `SILENT` being a threshold rather than a level.

**Every output sample in it is real**, captured by running the library rather than written by hand, and re-verified before commit.

**`docs/runtimes.md`** — entry points and per-runtime behaviour, including why the main entry stays browser-safe and what the trade-off is.

**`docs/README.md`** — a documentation index, grouped by using / integrating / maintaining / design. Fourteen documents had accumulated with no way in.

**`CONTRIBUTING.md`** — setup, commands, architecture with the file tree, tests, and the release process. Records two invariants a contributor cannot infer from the code:

- No `node:` specifier may become reachable from `src/index.ts` or `src/browser.ts`, with the command to check it
- A config field nothing reads is indistinguishable from a working one — five shipped that way (#44, #58, #60, #65, #67), and `tests/config-environment.test.ts` now has a guard test to extend

## Verification

- Every relative link and in-page anchor across all five files resolves (scripted check, GitHub's slug rules)
- Renamed one section to avoid two headings colliding on the same `#transports` slug, which had forced a fragile `#transports-1` anchor
- 238 tests pass, tsc clean, biome clean, `deno task check` 0 errors, publint clean
- `README.md` still ships in the tarball; `docs/` and `CONTRIBUTING.md` deliberately do not

## Release

`README.md` is in `package.json#files`, so this is **not** covered by `paths-ignore` and will cut a patch — which is right, since npm renders the README and the page needs refreshing.

`docs:` → patch. No breaking marker.

## Left for later

The API Reference section was dropped rather than moved. [JSR generates API docs from source](https://jsr.io/@logan/logger/doc), which is better than a hand-maintained copy and cannot drift; the README links there instead.
