### PR TITLE
feat(config): apply environment variables and config.metadata

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -53,7 +53,7 @@ LOG_FORMAT=text
 **Controls whether timestamps are included in log output.**
 
 **Variable:** `LOG_TIMESTAMP`  
-**Values:** `true`, `false`  
+**Values:** `true`, `1`, `yes`, `on` / `false`, `0`, `no`, `off` (case-insensitive)  
 **Default:** `true`
 
 ```bash
@@ -69,7 +69,7 @@ LOG_TIMESTAMP=false
 **Controls whether colored output is used (when supported by runtime).**
 
 **Variable:** `LOG_COLOR`  
-**Values:** `true`, `false`  
+**Values:** `true`, `1`, `yes`, `on` / `false`, `0`, `no`, `off` (case-insensitive)  
 **Default:** Auto-detected based on runtime capabilities
 
 ```bash
@@ -168,14 +168,58 @@ env:
   LOG_COLOR: false
 ```
 
+## What actually takes effect on 1.x
+
+> **Read this before relying on any variable other than `LOG_LEVEL`.**
+
+Until 1.2.0 none of these variables did anything at all: `loadConfigFromEnvironment()`
+parsed them correctly but nothing ever called it. They are now wired into
+`createLogger()`. However, the 1.x formatter still does not read `format`,
+`timestamp` or `colorize` from the config, so:
+
+| Variable | On 1.x |
+|---|---|
+| `LOG_LEVEL` | **works** |
+| `LOG_FORMAT` | parsed and merged, but Node output is unaffected |
+| `LOG_TIMESTAMP` | parsed and merged, but Node output is unaffected |
+| `LOG_COLOR` | parsed and merged; affects the browser logger's CSS styling only |
+
+The three inert ones are [#60](https://github.com/llbbl/logan-logger-ts/issues/60),
+fixed in 2.0 and deliberately not backported — honoring them means rewriting
+`NodeLogger`'s output path, which is the 2.0 transport work and too large a
+change for a maintenance line. `tests/config-environment.test.ts` pins the
+limitation so it cannot be rediscovered by accident.
+
+**All four work on 2.0.** If you need `LOG_FORMAT` or `LOG_TIMESTAMP`, that is a
+reason to upgrade.
+
 ## Priority Order
 
-Environment variables are loaded in this priority order (highest to lowest):
+Highest to lowest:
 
-1. **Environment variables** (e.g., `LOG_LEVEL`)
+1. **Environment variables** (e.g. `LOG_LEVEL`)
 2. **Manual configuration** passed to `createLogger(config)`
 3. **Environment-based defaults** from `NODE_ENV`, `NEXT_PUBLIC_APP_ENV`, `ENVIRONMENT`
 4. **Library defaults**
+
+Environment variables sit at the top deliberately, so an operator can change
+logging on a running service without a deploy. A library that must pin its own
+logging regardless of the host application's environment opts out:
+
+```typescript
+const logger = createLogger({ level: LogLevel.WARN, ignoreEnvironment: true });
+```
+
+**Config files are not in this chain.** `loadConfigFromFile()` is exported and
+usable directly, but `createLogger()` is synchronous and cannot await it. See
+[#58](https://github.com/llbbl/logan-logger-ts/issues/58).
+
+### Unrecognized values
+
+A variable that does not parse is **ignored with a warning**, falling through to
+the next source rather than resolving to a default. `LOG_LEVEL=verbose` does not
+silently become `info`, and `LOG_TIMESTAMP=maybe` does not silently turn
+timestamps off. Each distinct problem warns once per process.
 
 ## Runtime Considerations
 

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -13,25 +13,9 @@ export * from './utils/serialization.ts';
 import { type ILogger, type LoggerConfig, LogLevel } from './core/types.ts';
 // Browser-specific factory functions (avoid importing Node.js factory)
 import { BrowserLogger } from './runtime/browser.ts';
-import { detectRuntime } from './utils/runtime.ts';
-
-function getDefaultBrowserConfig(): LoggerConfig {
-  const runtime = detectRuntime();
-
-  return {
-    level: LogLevel.INFO,
-    format: 'text',
-    timestamp: true,
-    colorize: runtime.capabilities.colorSupport,
-    metadata: {},
-    transports: [
-      {
-        type: 'console',
-        options: {},
-      },
-    ],
-  };
-}
+// utils/config.ts is free of Node specifiers by design; the file-loading half
+// lives in utils/config-file.ts and is deliberately not imported here.
+import { loadConfigFromEnvironment, mergeConfigs } from './utils/config.ts';
 
 function getBrowserEnvironment(): string {
   // Check various environment variables
@@ -74,17 +58,12 @@ function getLogLevelForBrowserEnvironment(env: string): LogLevel {
  * Creates a BrowserLogger instance without importing Node.js dependencies.
  */
 export function createLogger(config: Partial<LoggerConfig> = {}): ILogger {
-  const defaultConfig = getDefaultBrowserConfig();
-  const mergedConfig = {
-    ...defaultConfig,
-    ...config,
-    metadata: {
-      ...defaultConfig.metadata,
-      ...config.metadata,
-    },
-  };
+  // Same precedence as the main factory: defaults < explicit config <
+  // environment. In a browser the LOG_* variables exist only if the bundler
+  // inlined them at build time, in which case this is a no-op.
+  const environment = config.ignoreEnvironment ? {} : loadConfigFromEnvironment();
 
-  return new BrowserLogger(mergedConfig);
+  return new BrowserLogger(mergeConfigs(config, environment));
 }
 
 /**

--- a/src/bun.ts
+++ b/src/bun.ts
@@ -6,6 +6,7 @@ export { createLogger, createLoggerForEnvironment } from './core/factory.ts';
 // Re-export core functionality optimized for Bun
 export type { ILogger, LoggerConfig, LogLevel } from './core/types.ts';
 export { NodeLogger } from './runtime/node.ts';
+export * from './utils/config-file.ts';
 export * from './utils/config.ts';
 export * from './utils/formatting.ts';
 // Bun-specific utilities

--- a/src/core/factory.ts
+++ b/src/core/factory.ts
@@ -1,6 +1,6 @@
 import { BrowserLogger } from '../runtime/browser.ts';
 import { NodeLogger } from '../runtime/node.ts';
-import { getDefaultConfig } from '../utils/config.ts';
+import { loadConfigFromEnvironment, mergeConfigs, tryParseLogLevel } from '../utils/config.ts';
 import { detectRuntime } from '../utils/runtime.ts';
 import { type ILogger, type LoggerConfig, LogLevel } from './types.ts';
 
@@ -52,16 +52,26 @@ export class LoggerFactory {
     return parent.child(metadata);
   }
 
+  /**
+   * Assemble the effective configuration.
+   *
+   * Precedence, lowest to highest:
+   *
+   *     library defaults  <  explicit config  <  environment variables
+   *
+   * Environment variables win so that an operator can change logging on a
+   * running service without a deploy. A consumer that must not be overridden
+   * that way sets `ignoreEnvironment: true`.
+   *
+   * The config-file link of the chain documented in `docs/environment-variables.md`
+   * is still missing: `loadConfigFromFile` is async and this path is not.
+   */
   private static mergeConfig(userConfig: Partial<LoggerConfig>): Partial<LoggerConfig> {
-    const defaultConfig = getDefaultConfig();
-    return {
-      ...defaultConfig,
-      ...userConfig,
-      metadata: {
-        ...defaultConfig.metadata,
-        ...userConfig.metadata,
-      },
-    };
+    const environment = userConfig.ignoreEnvironment ? {} : loadConfigFromEnvironment();
+
+    // mergeConfigs seeds itself with getDefaultConfig(), so defaults must not
+    // be passed again here.
+    return mergeConfigs(userConfig, environment);
   }
 }
 
@@ -140,24 +150,16 @@ function getLogLevelForEnvironment(env: string): LogLevel {
   }
 }
 
-// Type-safe log level conversion
+/**
+ * Convert a level string to a `LogLevel`, falling back to INFO.
+ *
+ * Delegates to the single parser in `utils/config.ts`; use `tryParseLogLevel`
+ * directly when an unrecognized value should be distinguishable from `info`.
+ * @param level - The value to convert
+ * @returns The matching level, or `LogLevel.INFO`
+ */
 export function stringToLogLevel(level: string): LogLevel {
-  switch (level.toLowerCase()) {
-    case 'debug':
-      return LogLevel.DEBUG;
-    case 'info':
-      return LogLevel.INFO;
-    case 'warn':
-    case 'warning':
-      return LogLevel.WARN;
-    case 'error':
-      return LogLevel.ERROR;
-    case 'silent':
-    case 'none':
-      return LogLevel.SILENT;
-    default:
-      return LogLevel.INFO;
-  }
+  return tryParseLogLevel(level) ?? LogLevel.INFO;
 }
 
 export function logLevelToString(level: LogLevel): string {

--- a/src/core/logger.ts
+++ b/src/core/logger.ts
@@ -19,6 +19,10 @@ export abstract class BaseLogger implements ILogger {
     this.config = config;
     this.level = config.level ?? LogLevel.INFO;
     this.runtime = detectRuntime().name;
+    // config.metadata is the documented "default metadata on every message".
+    // Seeding childMetadata is what makes that true, and it inherits through
+    // child() for free.
+    this.childMetadata = { ...config.metadata };
   }
 
   // biome-ignore lint/suspicious/noExplicitAny: Intentional - logger accepts arbitrary metadata (see ILogger interface)

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -68,6 +68,15 @@ export interface LoggerConfig {
   metadata: Record<string, any>;
   /** Transport configurations for log output */
   transports?: TransportConfig[];
+  /**
+   * Ignore `LOG_LEVEL`, `LOG_FORMAT`, `LOG_TIMESTAMP` and `LOG_COLOR`.
+   *
+   * Environment variables normally sit at the top of the precedence chain so an
+   * operator can raise verbosity on a running service without a deploy. A
+   * library that must pin its own logging regardless of the host application's
+   * environment sets this instead.
+   */
+  ignoreEnvironment?: boolean;
 }
 
 /**

--- a/src/deno.ts
+++ b/src/deno.ts
@@ -6,6 +6,7 @@ export { createLogger, createLoggerForEnvironment } from './core/factory.ts';
 // Re-export core functionality optimized for Deno
 export type { ILogger, LoggerConfig, LogLevel } from './core/types.ts';
 export { BrowserLogger, ConsoleGroupLogger, PerformanceLogger } from './runtime/browser.ts';
+export * from './utils/config-file.ts';
 export * from './utils/config.ts';
 export * from './utils/formatting.ts';
 // Deno-specific utilities

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export * from './core/types.ts';
 
 // Runtime-specific exports
 export { BrowserLogger, ConsoleGroupLogger, PerformanceLogger } from './runtime/browser.ts';
+export * from './utils/config-file.ts';
 export * from './utils/config.ts';
 export * from './utils/formatting.ts';
 // Utilities

--- a/src/utils/config-file.ts
+++ b/src/utils/config-file.ts
@@ -1,0 +1,92 @@
+import type { LoggerConfig } from '../core/types.ts';
+import { detectRuntime } from './runtime.ts';
+
+export async function loadConfigFromFile(configPath?: string): Promise<Partial<LoggerConfig>> {
+  const runtime = detectRuntime();
+
+  if (!runtime.capabilities.fileSystem) {
+    return {};
+  }
+
+  const possiblePaths = configPath
+    ? [configPath]
+    : [
+        'logan.config.json',
+        'logan.config.js',
+        '.loganrc',
+        'package.json', // Check for logan config in package.json
+      ];
+
+  for (const path of possiblePaths) {
+    try {
+      if (runtime.name === 'node') {
+        return await loadNodeConfig(path);
+      } else if (runtime.name === 'deno') {
+        return await loadDenoConfig(path);
+      } else if (runtime.name === 'bun') {
+        return await loadBunConfig(path);
+      }
+    } catch (error) {
+      // Continue to the next path if file doesn't exist or can't be loaded
+      void error; // Suppress unused variable warning
+    }
+  }
+
+  return {};
+}
+
+async function loadNodeConfig(path: string): Promise<Partial<LoggerConfig>> {
+  try {
+    const fs = await import('node:fs/promises');
+    const pathModule = await import('node:path');
+
+    if (path.endsWith('.json')) {
+      const content = await fs.readFile(path, 'utf-8');
+      const parsed = JSON.parse(content);
+
+      if (path === 'package.json') {
+        return parsed.logan || {};
+      }
+      return parsed;
+    } else if (path.endsWith('.js')) {
+      const fullPath = pathModule.resolve(path);
+      // Use file URL for cross-platform dynamic import compatibility
+      const fileUrl = `file://${fullPath}`;
+      const config = await import(/* @vite-ignore */ fileUrl);
+      return config.default || config;
+    }
+  } catch (error) {
+    // File doesn't exist or can't be parsed
+    void error; // Suppress unused variable warning
+  }
+
+  return {};
+}
+
+async function loadDenoConfig(path: string): Promise<Partial<LoggerConfig>> {
+  try {
+    if (path.endsWith('.json')) {
+      // biome-ignore lint/suspicious/noExplicitAny: Deno runtime not in TS types
+      const content = await (globalThis as any).Deno.readTextFile(path);
+      const parsed = JSON.parse(content);
+
+      if (path === 'package.json') {
+        return parsed.logan || {};
+      }
+      return parsed;
+    } else if (path.endsWith('.js')) {
+      const config = await import(/* @vite-ignore */ `./${path}`);
+      return config.default || config;
+    }
+  } catch (error) {
+    // File doesn't exist or can't be parsed
+    void error; // Suppress unused variable warning
+  }
+
+  return {};
+}
+
+async function loadBunConfig(path: string): Promise<Partial<LoggerConfig>> {
+  // Bun can use Node.js-style require or ES modules
+  return loadNodeConfig(path);
+}

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -19,129 +19,41 @@ export function getDefaultConfig(): LoggerConfig {
   };
 }
 
-export function loadConfigFromEnvironment(): Partial<LoggerConfig> {
-  const config: Partial<LoggerConfig> = {};
+/** Environment variable values accepted as `true`. */
+const TRUTHY = ['true', '1', 'yes', 'on'];
 
-  // Check for environment variables
-  if (typeof process !== 'undefined' && process.env) {
-    const env = process.env;
+/** Environment variable values accepted as `false`. */
+const FALSY = ['false', '0', 'no', 'off'];
 
-    // Log level
-    if (env.LOG_LEVEL) {
-      config.level = stringToLogLevel(env.LOG_LEVEL);
-    }
+/**
+ * Messages already emitted, so a misconfigured variable warns once rather than
+ * once per logger constructed.
+ */
+const warned = new Set<string>();
 
-    // Format
-    if (env.LOG_FORMAT && ['json', 'text'].includes(env.LOG_FORMAT)) {
-      config.format = env.LOG_FORMAT as 'json' | 'text';
-    }
-
-    // Timestamp
-    if (env.LOG_TIMESTAMP) {
-      config.timestamp = env.LOG_TIMESTAMP.toLowerCase() === 'true';
-    }
-
-    // Colorize
-    if (env.LOG_COLOR) {
-      config.colorize = env.LOG_COLOR.toLowerCase() === 'true';
-    }
+function warnOnce(message: string): void {
+  if (warned.has(message)) {
+    return;
   }
 
-  return config;
+  warned.add(message);
+  console.warn(message);
 }
 
-export async function loadConfigFromFile(configPath?: string): Promise<Partial<LoggerConfig>> {
-  const runtime = detectRuntime();
-
-  if (!runtime.capabilities.fileSystem) {
-    return {};
-  }
-
-  const possiblePaths = configPath
-    ? [configPath]
-    : [
-        'logan.config.json',
-        'logan.config.js',
-        '.loganrc',
-        'package.json', // Check for logan config in package.json
-      ];
-
-  for (const path of possiblePaths) {
-    try {
-      if (runtime.name === 'node') {
-        return await loadNodeConfig(path);
-      } else if (runtime.name === 'deno') {
-        return await loadDenoConfig(path);
-      } else if (runtime.name === 'bun') {
-        return await loadBunConfig(path);
-      }
-    } catch (error) {
-      // Continue to the next path if file doesn't exist or can't be loaded
-      void error; // Suppress unused variable warning
-    }
-  }
-
-  return {};
+/**
+ * Reset the warn-once state. Exposed for tests; not part of the public contract.
+ */
+export function resetEnvironmentWarnings(): void {
+  warned.clear();
 }
 
-async function loadNodeConfig(path: string): Promise<Partial<LoggerConfig>> {
-  try {
-    const fs = await import('node:fs/promises');
-    const pathModule = await import('node:path');
-
-    if (path.endsWith('.json')) {
-      const content = await fs.readFile(path, 'utf-8');
-      const parsed = JSON.parse(content);
-
-      if (path === 'package.json') {
-        return parsed.logan || {};
-      }
-      return parsed;
-    } else if (path.endsWith('.js')) {
-      const fullPath = pathModule.resolve(path);
-      // Use file URL for cross-platform dynamic import compatibility
-      const fileUrl = `file://${fullPath}`;
-      const config = await import(/* @vite-ignore */ fileUrl);
-      return config.default || config;
-    }
-  } catch (error) {
-    // File doesn't exist or can't be parsed
-    void error; // Suppress unused variable warning
-  }
-
-  return {};
-}
-
-async function loadDenoConfig(path: string): Promise<Partial<LoggerConfig>> {
-  try {
-    if (path.endsWith('.json')) {
-      // biome-ignore lint/suspicious/noExplicitAny: Deno runtime not in TS types
-      const content = await (globalThis as any).Deno.readTextFile(path);
-      const parsed = JSON.parse(content);
-
-      if (path === 'package.json') {
-        return parsed.logan || {};
-      }
-      return parsed;
-    } else if (path.endsWith('.js')) {
-      const config = await import(/* @vite-ignore */ `./${path}`);
-      return config.default || config;
-    }
-  } catch (error) {
-    // File doesn't exist or can't be parsed
-    void error; // Suppress unused variable warning
-  }
-
-  return {};
-}
-
-async function loadBunConfig(path: string): Promise<Partial<LoggerConfig>> {
-  // Bun can use Node.js-style require or ES modules
-  return loadNodeConfig(path);
-}
-
-function stringToLogLevel(level: string): LogLevel {
-  switch (level.toLowerCase()) {
+/**
+ * Parse a log level string, reporting failure rather than guessing.
+ * @param level - The value to parse
+ * @returns The matching level, or undefined if the value is not recognized
+ */
+export function tryParseLogLevel(level: string): LogLevel | undefined {
+  switch (level.trim().toLowerCase()) {
     case 'debug':
       return LogLevel.DEBUG;
     case 'info':
@@ -155,8 +67,98 @@ function stringToLogLevel(level: string): LogLevel {
     case 'none':
       return LogLevel.SILENT;
     default:
-      return LogLevel.INFO;
+      return undefined;
   }
+}
+
+/**
+ * Parse a boolean environment variable.
+ *
+ * An unrecognized value yields `undefined` rather than `false`, so a typo falls
+ * through to the next configuration source instead of silently turning the
+ * option off. `LOG_TIMESTAMP=1` disabling timestamps was the previous behavior.
+ */
+function parseBooleanEnvironment(name: string, raw: string): boolean | undefined {
+  const value = raw.trim().toLowerCase();
+
+  if (TRUTHY.includes(value)) {
+    return true;
+  }
+  if (FALSY.includes(value)) {
+    return false;
+  }
+
+  warnOnce(
+    `[logan-logger] ${name}="${raw}" is not a recognized boolean and was ignored. ` +
+      `Accepted: ${TRUTHY.join(', ')} / ${FALSY.join(', ')}.`
+  );
+
+  return undefined;
+}
+
+/**
+ * Read logger configuration from `LOG_LEVEL`, `LOG_FORMAT`, `LOG_TIMESTAMP`
+ * and `LOG_COLOR`.
+ *
+ * Only variables that are set and parse successfully appear in the result, so
+ * an absent or malformed variable leaves lower-precedence sources untouched.
+ *
+ * In a browser these values exist only if the bundler inlined them at build
+ * time; otherwise this returns an empty object.
+ * @returns The subset of configuration the environment specifies
+ */
+export function loadConfigFromEnvironment(): Partial<LoggerConfig> {
+  const config: Partial<LoggerConfig> = {};
+
+  if (typeof process === 'undefined' || !process.env) {
+    return config;
+  }
+
+  const env = process.env;
+
+  if (env.LOG_LEVEL) {
+    const level = tryParseLogLevel(env.LOG_LEVEL);
+
+    if (level === undefined) {
+      warnOnce(
+        `[logan-logger] LOG_LEVEL="${env.LOG_LEVEL}" is not a recognized level and was ` +
+          'ignored. Accepted: debug, info, warn, error, silent.'
+      );
+    } else {
+      config.level = level;
+    }
+  }
+
+  if (env.LOG_FORMAT) {
+    const format = env.LOG_FORMAT.trim().toLowerCase();
+
+    if (format === 'json' || format === 'text') {
+      config.format = format;
+    } else {
+      warnOnce(
+        `[logan-logger] LOG_FORMAT="${env.LOG_FORMAT}" is not a recognized format and was ` +
+          'ignored. Accepted: json, text.'
+      );
+    }
+  }
+
+  if (env.LOG_TIMESTAMP) {
+    const timestamp = parseBooleanEnvironment('LOG_TIMESTAMP', env.LOG_TIMESTAMP);
+
+    if (timestamp !== undefined) {
+      config.timestamp = timestamp;
+    }
+  }
+
+  if (env.LOG_COLOR) {
+    const colorize = parseBooleanEnvironment('LOG_COLOR', env.LOG_COLOR);
+
+    if (colorize !== undefined) {
+      config.colorize = colorize;
+    }
+  }
+
+  return config;
 }
 
 export function mergeConfigs(...configs: Partial<LoggerConfig>[]): LoggerConfig {

--- a/tests/config-environment.test.ts
+++ b/tests/config-environment.test.ts
@@ -1,0 +1,270 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createLogger as createBrowserLogger } from '../src/browser.ts';
+import { createLogger, createLoggerForEnvironment } from '../src/core/factory.ts';
+import { LogLevel } from '../src/core/types.ts';
+import { resetEnvironmentWarnings } from '../src/utils/config.ts';
+
+const LOG_VARIABLES = ['LOG_LEVEL', 'LOG_FORMAT', 'LOG_TIMESTAMP', 'LOG_COLOR'] as const;
+
+let saved: Record<string, string | undefined>;
+
+/** Capture whatever the logger writes to the console, whichever method it uses. */
+function captureConsole() {
+  const lines: string[] = [];
+  const record = (value: unknown) => {
+    lines.push(String(value));
+  };
+
+  for (const method of ['debug', 'info', 'warn', 'error'] as const) {
+    vi.spyOn(console, method).mockImplementation(record);
+  }
+
+  return lines;
+}
+
+beforeEach(() => {
+  saved = {};
+  for (const name of LOG_VARIABLES) {
+    saved[name] = process.env[name];
+    delete process.env[name];
+  }
+  resetEnvironmentWarnings();
+});
+
+afterEach(() => {
+  for (const name of LOG_VARIABLES) {
+    if (saved[name] === undefined) {
+      delete process.env[name];
+    } else {
+      process.env[name] = saved[name];
+    }
+  }
+  vi.restoreAllMocks();
+});
+
+describe('environment variables reach the logger', () => {
+  it('should apply LOG_LEVEL', () => {
+    process.env.LOG_LEVEL = 'debug';
+
+    expect(createLogger().getLevel()).toBe(LogLevel.DEBUG);
+  });
+
+  it('should silence everything at LOG_LEVEL=silent', () => {
+    process.env.LOG_LEVEL = 'silent';
+    const lines = captureConsole();
+
+    const logger = createLogger();
+    logger.debug('d');
+    logger.info('i');
+    logger.warn('w');
+    logger.error('e');
+
+    expect(lines).toEqual([]);
+  });
+
+  it.each([
+    ['warning', LogLevel.WARN],
+    ['none', LogLevel.SILENT],
+    ['ERROR', LogLevel.ERROR],
+    ['  info  ', LogLevel.INFO],
+  ])('should accept LOG_LEVEL=%s', (value, expected) => {
+    process.env.LOG_LEVEL = value;
+
+    expect(createLogger().getLevel()).toBe(expected);
+  });
+});
+
+/**
+ * On the 1.x line the formatter never receives the config, so `format`,
+ * `timestamp` and `colorize` change nothing about Node output. That is #60,
+ * fixed in 2.0 and deliberately **not** backported: honoring them means
+ * rewriting NodeLogger's output path, which is the 2.0 transport work.
+ *
+ * These tests pin the limitation rather than leaving it to be rediscovered. If
+ * one of them starts failing, the formatter has gained config awareness and the
+ * docs need updating to match.
+ */
+describe('variables that are parsed but not honored on 1.x', () => {
+  it('should not change Node output for LOG_FORMAT', () => {
+    process.env.LOG_FORMAT = 'json';
+    const lines = captureConsole();
+
+    createLogger().info('still text');
+
+    expect(lines[0]).toMatch(/^\[\d{4}-/);
+    expect(() => JSON.parse(lines[0])).toThrow();
+  });
+
+  it('should not change Node output for LOG_TIMESTAMP', () => {
+    process.env.LOG_TIMESTAMP = 'false';
+    const lines = captureConsole();
+
+    createLogger().info('still stamped');
+
+    expect(lines[0]).toMatch(/^\[\d{4}-/);
+  });
+
+  it('should still reach the resolved config, so a fix to #60 picks them up', () => {
+    process.env.LOG_FORMAT = 'json';
+    process.env.LOG_TIMESTAMP = 'false';
+
+    // The values are parsed and merged; only the formatter ignores them.
+    const logger = createLogger() as unknown as { config: Record<string, unknown> };
+
+    expect(logger.config.format).toBe('json');
+    expect(logger.config.timestamp).toBe(false);
+  });
+});
+
+describe('precedence', () => {
+  it('should let the environment override explicit config', () => {
+    process.env.LOG_LEVEL = 'debug';
+
+    expect(createLogger({ level: LogLevel.ERROR }).getLevel()).toBe(LogLevel.DEBUG);
+  });
+
+  it('should leave explicit config alone when the variable is unset', () => {
+    expect(createLogger({ level: LogLevel.ERROR }).getLevel()).toBe(LogLevel.ERROR);
+  });
+
+  it('should honor ignoreEnvironment', () => {
+    process.env.LOG_LEVEL = 'debug';
+
+    expect(createLogger({ level: LogLevel.ERROR, ignoreEnvironment: true }).getLevel()).toBe(
+      LogLevel.ERROR
+    );
+  });
+
+  it('should let LOG_LEVEL override the NODE_ENV-derived level', () => {
+    const original = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+    process.env.LOG_LEVEL = 'debug';
+
+    try {
+      expect(createLoggerForEnvironment().getLevel()).toBe(LogLevel.DEBUG);
+    } finally {
+      process.env.NODE_ENV = original;
+    }
+  });
+
+  it('should apply the same rules from the browser entry point', () => {
+    process.env.LOG_LEVEL = 'error';
+
+    expect(createBrowserLogger().getLevel()).toBe(LogLevel.ERROR);
+    expect(createBrowserLogger({ ignoreEnvironment: true }).getLevel()).toBe(LogLevel.INFO);
+  });
+});
+
+describe('malformed values', () => {
+  it('should treat LOG_TIMESTAMP=1 as true rather than false', () => {
+    process.env.LOG_TIMESTAMP = '1';
+
+    // The strict `=== 'true'` rule made every non-"true" value mean false.
+    const logger = createLogger() as unknown as { config: Record<string, unknown> };
+
+    expect(logger.config.timestamp).toBe(true);
+  });
+
+  it.each([
+    ['yes', true],
+    ['on', true],
+    ['TRUE', true],
+    [' true ', true],
+    ['no', false],
+    ['off', false],
+    ['0', false],
+    ['FALSE', false],
+  ])('should parse LOG_COLOR=%s as %s', (value, expected) => {
+    process.env.LOG_COLOR = value;
+
+    const logger = createLogger() as unknown as { config: Record<string, unknown> };
+
+    expect(logger.config.colorize).toBe(expected);
+  });
+
+  it('should warn and fall through to explicit config rather than choosing a side', () => {
+    process.env.LOG_TIMESTAMP = 'banana';
+    const lines = captureConsole();
+
+    const logger = createLogger({ timestamp: false }) as unknown as {
+      config: Record<string, unknown>;
+    };
+
+    expect(lines.some((line) => line.includes('LOG_TIMESTAMP="banana"'))).toBe(true);
+    // The explicit timestamp:false survives; the bad value does not flip it.
+    expect(logger.config.timestamp).toBe(false);
+  });
+
+  it('should warn and ignore an unrecognized LOG_LEVEL rather than defaulting to INFO', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    process.env.LOG_LEVEL = 'verbose';
+
+    expect(createLogger({ level: LogLevel.ERROR }).getLevel()).toBe(LogLevel.ERROR);
+    expect(warn.mock.calls[0][0]).toContain('LOG_LEVEL="verbose"');
+  });
+
+  it('should warn and ignore an unrecognized LOG_FORMAT', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    process.env.LOG_FORMAT = 'yaml';
+
+    createLogger();
+
+    expect(warn.mock.calls[0][0]).toContain('LOG_FORMAT="yaml"');
+  });
+
+  it('should warn once, not once per logger', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    process.env.LOG_LEVEL = 'verbose';
+
+    createLogger();
+    createLogger();
+    createLogger();
+
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('config.metadata is emitted', () => {
+  it('should include config.metadata on every record', () => {
+    const lines = captureConsole();
+
+    createLogger({ metadata: { service: 'api' }, ignoreEnvironment: true }).info('with defaults');
+
+    expect(lines[0]).toContain('"service":"api"');
+  });
+
+  it('should let call-site metadata override config.metadata', () => {
+    const lines = captureConsole();
+
+    createLogger({ metadata: { stage: 'default' }, ignoreEnvironment: true }).info('x', {
+      stage: 'override',
+    });
+
+    expect(lines[0]).toContain('"stage":"override"');
+    expect(lines[0]).not.toContain('default');
+  });
+
+  it('should inherit config.metadata through child loggers', () => {
+    const lines = captureConsole();
+
+    createLogger({ metadata: { service: 'api' }, ignoreEnvironment: true })
+      .child({ requestId: 'req-1' })
+      .info('child');
+
+    expect(lines[0]).toContain('"service":"api"');
+    expect(lines[0]).toContain('"requestId":"req-1"');
+  });
+
+  it('should not leak a parent mutation back into config.metadata', () => {
+    const metadata = { service: 'api' };
+    const logger = createLogger({ metadata, ignoreEnvironment: true });
+    const lines = captureConsole();
+
+    logger.child({ extra: 1 });
+    logger.info('parent unchanged');
+
+    expect(lines[0]).toContain('"service":"api"');
+    expect(lines[0]).not.toContain('extra');
+    expect(metadata).toEqual({ service: 'api' });
+  });
+});

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,10 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { logLevelToString, stringToLogLevel } from '../src/core/factory.ts';
 import { type LoggerConfig, LogLevel } from '../src/core/types.ts';
+import { loadConfigFromFile } from '../src/utils/config-file.ts';
 import {
   getDefaultConfig,
   loadConfigFromEnvironment,
-  loadConfigFromFile,
   mergeConfigs,
 } from '../src/utils/config.ts';
 


### PR DESCRIPTION
Backport of #65 and #67 to the `1.x` maintenance line. Hand-written rather than cherry-picked: #64 squashed both together with the Winston removal and the `config.ts` split, so none of those commits apply here.

**This is a `feat:`, not a `fix:` — it lands as `v1.2.0` under the `v1-lts` dist-tag.** Both changes alter behaviour for anyone already setting the affected values.

## #67 — `config.metadata` is emitted

One line in `BaseLogger`. The field was documented as "default metadata to include with all log messages", initialized by `getDefaultConfig()`, merged explicitly by both `LoggerFactory.mergeConfig` and `mergeConfigs()`, covered by tests — and then never read, because `log()` built each record from `childMetadata` and the call site only.

```ts
this.childMetadata = { ...config.metadata };
```

Children inherit it for free, since `child()` already spreads `this.childMetadata`. Call-site metadata still wins on collisions.

## #65 — environment variables reach the logger

`LoggerFactory.mergeConfig` now uses the existing `mergeConfigs()` — variadic, precedence-aware, previously called from nowhere in `src/` — and folds the environment in at the top: `defaults < explicit config < environment`. New `LoggerConfig.ignoreEnvironment` opts out, for a library that must pin its own logging against a host application's environment.

Also brought across from the 2.0 fix:

- **Boolean parsing.** `LOG_TIMESTAMP=1` resolved to `false` under the old `=== 'true'` rule. Harmless while nothing read it; indefensible now. Accepts `true/1/yes/on` and `false/0/no/off`.
- **Unparseable values warn once and are ignored**, falling through rather than resolving to a default. `LOG_LEVEL=verbose` no longer silently becomes `info`.
- **Level parsing existed twice** — a private copy in `config.ts` and the exported one in `factory.ts`. `factory.stringToLogLevel` now delegates to a single `tryParseLogLevel`.
- **`src/browser.ts` had the same hole** via a duplicated `getDefaultBrowserConfig()`. It now shares `utils/config.ts`.

`src/utils/config.ts` is split the same way as on `main`, so the pure half carries no Node specifiers and is safe for the browser entry to import. File loaders move to `src/utils/config-file.ts`, still re-exported from the index, deno and bun entries — the public API is unchanged, and `dist/browser.mjs` still contains no `node:` specifier.

Keeping the file layout identical to `main` is deliberate: divergent structure makes every future backport harder.

## The part that needs your attention

**Only `LOG_LEVEL` actually takes effect on this line.** Verified against the branch:

```
LOG_LEVEL=debug      -> DEBUG    WORKS
LOG_FORMAT=json      -> INERT    formatter ignores config.format on 1.x
LOG_TIMESTAMP=false  -> INERT    formatter ignores config.timestamp on 1.x
config.metadata      -> WORKS
```

That is [#60](https://github.com/llbbl/logan-logger-ts/issues/60): the 1.x formatter never receives the config. It is fixed in 2.0 and **deliberately not backported** — honoring those three means rewriting `NodeLogger`'s output path, which is the 2.0 transport work and far past the "security fixes and correctness bugs" bar in `docs/maintenance-releases.md`.

Shipping this while claiming "environment variables now work" would recreate exactly the declared-but-ignored problem this whole series has been about. So instead:

- `tests/config-environment.test.ts` has a **`variables that are parsed but not honored on 1.x`** block that asserts `LOG_FORMAT` and `LOG_TIMESTAMP` do *not* change Node output, and that they *do* reach the resolved config. If someone later fixes the formatter, those tests fail and force the docs to be updated.
- `docs/environment-variables.md` opens with a table of what actually takes effect, and says plainly that needing `LOG_FORMAT` or `LOG_TIMESTAMP` is a reason to upgrade to 2.0.

I would rather ship a partial fix that is honest about its edges than a complete-looking one that is not. If you would rather hold #65 back and ship only #67, say so and I will split it.

## Ported deliberately without `shouldColorize()`

2.0 gates the `colorize` default on TTY detection, `NO_COLOR` and `FORCE_COLOR`. That is part of #60 and pointless here — the Node formatter ignores `colorize` entirely on 1.x, and the browser logger, which does read it, has no TTY. `getDefaultConfig()` keeps its existing `capabilities.colorSupport`.

## Verification

```
vitest      208 passed | 7 skipped   (was 177)
tsc         clean
biome       clean
deno check  0 errors
publint     no problems
build       dist/browser.mjs contains no node: specifier
```

Closes #65. Closes #67.
