### PR TITLE
feat(config): make every advertised config file source reachable

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,9 +32,17 @@ Environment variables sit on top so an operator can change logging on a running
 service without a deploy. A library that must pin its own logging regardless of
 the host application's environment sets [`ignoreEnvironment`](#ignoreenvironment).
 
-**Config files are not in this chain.** `loadConfigFromFile()` is exported and
-usable directly, but `createLogger()` is synchronous and cannot await it — see
-[#58](https://github.com/llbbl/logan-logger-ts/issues/58).
+**Config files are applied explicitly, not automatically.** `createLogger()` is
+synchronous and `loadConfigFromFile()` is not, so file configuration cannot sit
+in the chain above on its own. Opt in by awaiting it:
+
+```typescript
+const logger = createLogger(await loadConfigFromFile());
+```
+
+Placed there it behaves as the lowest-priority source, since explicit config and
+the environment are both applied on top. See
+[Config files](#config-files) below.
 
 ---
 
@@ -222,6 +230,68 @@ bundlers only inline their own prefixed names by default. Map them explicitly
 (Vite's `define`, for instance) if you want them.
 
 Full detail in [environment-variables.md](./environment-variables.md).
+
+---
+
+## Config files
+
+`loadConfigFromFile()` searches the working directory, in order, and returns the
+first candidate that exists:
+
+| File | Read from |
+|---|---|
+| `logan.config.json` | the whole file |
+| `.loganrc` | the whole file, parsed as **JSON** |
+| `package.json` | the `logan` key |
+
+A `package.json` with no `logan` key counts as absent, so the search continues
+rather than stopping with an empty config.
+
+```typescript
+import { createLogger, loadConfigFromFile } from 'logan-logger';
+
+const logger = createLogger(await loadConfigFromFile());
+```
+
+Pass a path to load exactly one file and skip the search. **A missing file is
+then an error**, not a silent fallback — asking for a specific file that is not
+there is a caller mistake:
+
+```typescript
+await loadConfigFromFile('config/logging.json');   // throws if absent
+```
+
+### Values are normalized
+
+A config file naturally writes `"level": "debug"` — a string, where the runtime
+expects a `LogLevel` ordinal. The loader converts it. Handing the raw JSON
+straight to the logger would make every `level >= this.level` comparison `NaN`
+and **silently discard every record**, so normalization is not optional:
+
+```json
+{ "level": "warn", "format": "json", "timestamp": false, "metadata": { "service": "api" } }
+```
+
+`level` accepts the same names as `LOG_LEVEL`, or a numeric ordinal. A field
+that is unrecognized or of the wrong type is dropped with a warning naming the
+file and the field, rather than being passed through to fail later.
+
+### Failure is loud
+
+A candidate that is present but unreadable or malformed **warns naming the path
+and stops the search**. It does not fall through to the next candidate, because
+a broken config file is a mistake to surface rather than route around.
+
+"File does not exist" and "file exists but cannot be read" are distinguished: a
+permissions error on a config file that is really there is reported, not treated
+as absence.
+
+### No JavaScript config
+
+`logan.config.js` was advertised in 1.x and never actually reachable. It is
+gone. Supporting it meant dynamically importing and executing a file from the
+working directory during logger construction, and nothing in `LoggerConfig`
+needs to be computed — JSON covers the entire surface.
 
 ---
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -185,9 +185,11 @@ logging regardless of the host application's environment opts out:
 const logger = createLogger({ level: LogLevel.WARN, ignoreEnvironment: true });
 ```
 
-**Config files are not in this chain.** `loadConfigFromFile()` is exported and
-usable directly, but `createLogger()` is synchronous and cannot await it. See
-[#58](https://github.com/llbbl/logan-logger-ts/issues/58).
+**Config files are applied explicitly.** `createLogger()` is synchronous and
+`loadConfigFromFile()` is not, so opt in by awaiting it:
+`createLogger(await loadConfigFromFile())`. It then sits below both explicit
+config and the environment. See
+[configuration.md](./configuration.md#config-files).
 
 ### Unrecognized values
 

--- a/docs/maintenance-releases.md
+++ b/docs/maintenance-releases.md
@@ -98,6 +98,19 @@ recording why dist-tags were not adopted, and observably: `@hono/hono` reports
 `4.13.3` as latest while holding twelve `4.9.x` versions, so the ordering is
 semver-aware rather than lexicographic.
 
+## Issues do not auto-close from this branch
+
+GitHub only closes issues from commits merged into the **default** branch. A
+`Closes #N` in a merge to `1.x` is inert — the issue stays open with no
+indication that anything happened.
+
+Close it by hand after the release lands, and say why in the comment so the
+trail is not confusing later:
+
+```bash
+gh issue close <N> --comment "Backported in #<PR> and published as vX.Y.Z under v<major>-lts."
+```
+
 ## What is not automated
 
 - **Dependabot** targets the default branch only. A maintenance line does not

--- a/src/utils/config-file.ts
+++ b/src/utils/config-file.ts
@@ -1,6 +1,213 @@
-import type { LoggerConfig } from '../core/types.ts';
+import { type LoggerConfig, LogLevel } from '../core/types.ts';
+import { tryParseLogLevel } from './config.ts';
 import { detectRuntime } from './runtime.ts';
 
+/**
+ * A config file candidate.
+ *
+ * `key` extracts a sub-object, so a `package.json` without a `logan` key reads
+ * as absent rather than as an empty config that would stop the search.
+ */
+interface Candidate {
+  path: string;
+  key?: string;
+}
+
+/**
+ * Searched in order when no explicit path is given. All are JSON.
+ *
+ * `logan.config.js` used to be on this list. It was unreachable in practice,
+ * and supporting it meant dynamically importing and executing a file from the
+ * working directory during logger construction. Nothing in `LoggerConfig` needs
+ * to be computed, so JSON covers the whole surface without that.
+ */
+const CANDIDATES: Candidate[] = [
+  { path: 'logan.config.json' },
+  { path: '.loganrc' },
+  { path: 'package.json', key: 'logan' },
+];
+
+/**
+ * The three outcomes a candidate can produce. Conflating the first two is what
+ * made the original loader unable to iterate.
+ */
+type LoadOutcome =
+  | { kind: 'found'; config: Partial<LoggerConfig> }
+  | { kind: 'absent' }
+  | { kind: 'invalid'; path: string; reason: string };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function describe(cause: unknown): string {
+  return cause instanceof Error ? cause.message : String(cause);
+}
+
+/**
+ * Read a file, distinguishing "not there" from "there but unreadable".
+ * @returns The contents, or undefined when the file does not exist
+ * @throws When the file exists but cannot be read — a permissions problem is
+ * not the same as an absent file, and silently treating it as one is how a
+ * misconfigured deployment ends up on default settings.
+ */
+async function readTextFile(path: string, runtime: string): Promise<string | undefined> {
+  if (runtime === 'deno') {
+    try {
+      // biome-ignore lint/suspicious/noExplicitAny: Deno runtime not in TS types
+      return await (globalThis as any).Deno.readTextFile(path);
+    } catch (cause) {
+      // biome-ignore lint/suspicious/noExplicitAny: Deno runtime not in TS types
+      if (cause instanceof (globalThis as any).Deno.errors.NotFound) {
+        return undefined;
+      }
+      throw cause;
+    }
+  }
+
+  const fs = await import('node:fs/promises');
+
+  try {
+    return await fs.readFile(path, 'utf-8');
+  } catch (cause) {
+    if ((cause as NodeJS.ErrnoException)?.code === 'ENOENT') {
+      return undefined;
+    }
+    throw cause;
+  }
+}
+
+/**
+ * Coerce and validate the raw JSON into a `LoggerConfig` subset.
+ *
+ * A config file naturally writes `"level": "debug"` — a string, where the
+ * runtime expects a `LogLevel` ordinal. Passing that through unchanged makes
+ * every `level >= this.level` comparison NaN, which silently discards **all**
+ * records. Anything unrecognized is dropped with a warning rather than handed
+ * to the logger.
+ */
+function normalize(raw: Record<string, unknown>, path: string): Partial<LoggerConfig> {
+  const config: Partial<LoggerConfig> = {};
+  const reject = (field: string, value: unknown, accepted: string) => {
+    console.warn(
+      `[logan-logger] ${path}: ignoring ${field}=${JSON.stringify(value)}. Accepted: ${accepted}.`
+    );
+  };
+
+  if (raw.level !== undefined) {
+    if (typeof raw.level === 'string') {
+      const level = tryParseLogLevel(raw.level);
+      if (level === undefined) {
+        reject('level', raw.level, 'debug, info, warn, error, silent');
+      } else {
+        config.level = level;
+      }
+    } else if (typeof raw.level === 'number' && LogLevel[raw.level] !== undefined) {
+      config.level = raw.level;
+    } else {
+      reject('level', raw.level, 'debug, info, warn, error, silent');
+    }
+  }
+
+  if (raw.format !== undefined) {
+    if (raw.format === 'json' || raw.format === 'text') {
+      config.format = raw.format;
+    } else {
+      reject('format', raw.format, 'json, text');
+    }
+  }
+
+  for (const field of ['timestamp', 'colorize', 'ignoreEnvironment'] as const) {
+    if (raw[field] === undefined) {
+      continue;
+    }
+    if (typeof raw[field] === 'boolean') {
+      config[field] = raw[field];
+    } else {
+      reject(field, raw[field], 'true, false');
+    }
+  }
+
+  if (raw.metadata !== undefined) {
+    if (isRecord(raw.metadata)) {
+      config.metadata = raw.metadata;
+    } else {
+      reject('metadata', raw.metadata, 'an object');
+    }
+  }
+
+  if (Array.isArray(raw.transports)) {
+    config.transports = raw.transports as LoggerConfig['transports'];
+  } else if (raw.transports !== undefined) {
+    reject('transports', raw.transports, 'an array of transport configs');
+  }
+
+  return config;
+}
+
+async function loadCandidate(candidate: Candidate, runtime: string): Promise<LoadOutcome> {
+  let content: string | undefined;
+
+  try {
+    content = await readTextFile(candidate.path, runtime);
+  } catch (cause) {
+    return { kind: 'invalid', path: candidate.path, reason: describe(cause) };
+  }
+
+  if (content === undefined) {
+    return { kind: 'absent' };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch (cause) {
+    return { kind: 'invalid', path: candidate.path, reason: describe(cause) };
+  }
+
+  let raw: unknown = parsed;
+
+  if (candidate.key) {
+    if (!isRecord(parsed)) {
+      return { kind: 'invalid', path: candidate.path, reason: 'expected a JSON object' };
+    }
+    if (!(candidate.key in parsed)) {
+      // No `logan` key is not a config file at all; keep searching.
+      return { kind: 'absent' };
+    }
+    raw = parsed[candidate.key];
+  }
+
+  if (!isRecord(raw)) {
+    const where = candidate.key ? `the "${candidate.key}" key` : 'the file';
+    return { kind: 'invalid', path: candidate.path, reason: `expected ${where} to be an object` };
+  }
+
+  return { kind: 'found', config: normalize(raw, candidate.path) };
+}
+
+/**
+ * Load logger configuration from a file.
+ *
+ * Without an explicit path, searches `logan.config.json`, then `.loganrc`, then
+ * a `logan` key in `package.json`, and returns the first one present. All are
+ * parsed as JSON.
+ *
+ * A file that is present but unreadable or malformed **warns naming the path**
+ * and stops the search rather than silently falling through to defaults.
+ *
+ * This is async, and `createLogger()` is not, so file configuration is not part
+ * of the automatic precedence chain. Apply it explicitly:
+ *
+ * ```typescript
+ * const logger = createLogger(await loadConfigFromFile());
+ * ```
+ *
+ * @param configPath - Load exactly this file. Unlike the search, a missing file
+ * here is a caller error and throws.
+ * @returns The configuration found, or `{}` when no candidate exists
+ * @throws When `configPath` is given and that file does not exist
+ */
 export async function loadConfigFromFile(configPath?: string): Promise<Partial<LoggerConfig>> {
   const runtime = detectRuntime();
 
@@ -8,85 +215,33 @@ export async function loadConfigFromFile(configPath?: string): Promise<Partial<L
     return {};
   }
 
-  const possiblePaths = configPath
-    ? [configPath]
-    : [
-        'logan.config.json',
-        'logan.config.js',
-        '.loganrc',
-        'package.json', // Check for logan config in package.json
-      ];
+  if (configPath !== undefined) {
+    const outcome = await loadCandidate({ path: configPath }, runtime.name);
 
-  for (const path of possiblePaths) {
-    try {
-      if (runtime.name === 'node') {
-        return await loadNodeConfig(path);
-      } else if (runtime.name === 'deno') {
-        return await loadDenoConfig(path);
-      } else if (runtime.name === 'bun') {
-        return await loadBunConfig(path);
-      }
-    } catch (error) {
-      // Continue to the next path if file doesn't exist or can't be loaded
-      void error; // Suppress unused variable warning
+    if (outcome.kind === 'absent') {
+      // Asking for a specific file that is not there is a mistake worth
+      // surfacing, not something to paper over with defaults.
+      throw new Error(`[logan-logger] config file not found: ${configPath}`);
     }
+    if (outcome.kind === 'invalid') {
+      throw new Error(`[logan-logger] config at ${outcome.path} is invalid: ${outcome.reason}`);
+    }
+
+    return outcome.config;
+  }
+
+  for (const candidate of CANDIDATES) {
+    const outcome = await loadCandidate(candidate, runtime.name);
+
+    if (outcome.kind === 'found') {
+      return outcome.config;
+    }
+    if (outcome.kind === 'invalid') {
+      console.warn(`[logan-logger] config at ${outcome.path} is invalid: ${outcome.reason}`);
+      return {};
+    }
+    // 'absent' — keep searching.
   }
 
   return {};
-}
-
-async function loadNodeConfig(path: string): Promise<Partial<LoggerConfig>> {
-  try {
-    const fs = await import('node:fs/promises');
-    const pathModule = await import('node:path');
-
-    if (path.endsWith('.json')) {
-      const content = await fs.readFile(path, 'utf-8');
-      const parsed = JSON.parse(content);
-
-      if (path === 'package.json') {
-        return parsed.logan || {};
-      }
-      return parsed;
-    } else if (path.endsWith('.js')) {
-      const fullPath = pathModule.resolve(path);
-      // Use file URL for cross-platform dynamic import compatibility
-      const fileUrl = `file://${fullPath}`;
-      const config = await import(/* @vite-ignore */ fileUrl);
-      return config.default || config;
-    }
-  } catch (error) {
-    // File doesn't exist or can't be parsed
-    void error; // Suppress unused variable warning
-  }
-
-  return {};
-}
-
-async function loadDenoConfig(path: string): Promise<Partial<LoggerConfig>> {
-  try {
-    if (path.endsWith('.json')) {
-      // biome-ignore lint/suspicious/noExplicitAny: Deno runtime not in TS types
-      const content = await (globalThis as any).Deno.readTextFile(path);
-      const parsed = JSON.parse(content);
-
-      if (path === 'package.json') {
-        return parsed.logan || {};
-      }
-      return parsed;
-    } else if (path.endsWith('.js')) {
-      const config = await import(/* @vite-ignore */ `./${path}`);
-      return config.default || config;
-    }
-  } catch (error) {
-    // File doesn't exist or can't be parsed
-    void error; // Suppress unused variable warning
-  }
-
-  return {};
-}
-
-async function loadBunConfig(path: string): Promise<Partial<LoggerConfig>> {
-  // Bun can use Node.js-style require or ES modules
-  return loadNodeConfig(path);
 }

--- a/tests/config-file.test.ts
+++ b/tests/config-file.test.ts
@@ -1,0 +1,267 @@
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createLogger } from '../src/core/factory.ts';
+import { LogLevel } from '../src/core/types.ts';
+import { loadConfigFromFile } from '../src/utils/config-file.ts';
+
+/**
+ * Real files in a real directory rather than a mocked `fs`. The defects this
+ * suite covers were in path handling and control flow, which a mock papers over.
+ */
+let workspace: string;
+let originalCwd: string;
+
+/** Write a file into the workspace. */
+function put(name: string, contents: unknown) {
+  writeFileSync(
+    join(workspace, name),
+    typeof contents === 'string' ? contents : JSON.stringify(contents)
+  );
+}
+
+beforeEach(() => {
+  originalCwd = process.cwd();
+  workspace = mkdtempSync(join(tmpdir(), 'logan-config-'));
+  process.chdir(workspace);
+});
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  rmSync(workspace, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe('candidate search', () => {
+  it('should load logan.config.json', async () => {
+    put('logan.config.json', { level: 'warn' });
+
+    expect(await loadConfigFromFile()).toEqual({ level: LogLevel.WARN });
+  });
+
+  it('should fall through to .loganrc when logan.config.json is absent', async () => {
+    // Previously impossible: the loop returned on the first candidate whether
+    // or not it existed, and .loganrc matched neither extension branch.
+    put('.loganrc', { level: 'error' });
+
+    expect(await loadConfigFromFile()).toEqual({ level: LogLevel.ERROR });
+  });
+
+  it('should fall through to the logan key in package.json', async () => {
+    put('package.json', { name: 'app', logan: { level: 'debug' } });
+
+    expect(await loadConfigFromFile()).toEqual({ level: LogLevel.DEBUG });
+  });
+
+  it('should treat a package.json without a logan key as absent', async () => {
+    put('package.json', { name: 'app' });
+
+    // An empty config here would have stopped the search with {}.
+    expect(await loadConfigFromFile()).toEqual({});
+  });
+
+  it('should keep searching past a package.json without a logan key', async () => {
+    put('package.json', { name: 'app' });
+    put('.loganrc', { level: 'warn' });
+
+    expect(await loadConfigFromFile()).toEqual({ level: LogLevel.WARN });
+  });
+
+  it('should prefer the first candidate in order', async () => {
+    put('logan.config.json', { level: 'debug' });
+    put('.loganrc', { level: 'error' });
+    put('package.json', { logan: { level: 'silent' } });
+
+    expect(await loadConfigFromFile()).toEqual({ level: LogLevel.DEBUG });
+  });
+
+  it('should return an empty config when nothing is present', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    expect(await loadConfigFromFile()).toEqual({});
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('should no longer consider logan.config.js', async () => {
+    put('logan.config.js', 'export default { level: "debug" };');
+
+    // Dropped deliberately: it executed a file from the working directory
+    // during logger construction, and JSON covers the whole config surface.
+    expect(await loadConfigFromFile()).toEqual({});
+  });
+});
+
+describe('malformed input', () => {
+  it('should warn naming the path rather than silently returning defaults', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    put('logan.config.json', '{ this is not json');
+
+    expect(await loadConfigFromFile()).toEqual({});
+    expect(warn.mock.calls[0][0]).toContain('logan.config.json');
+  });
+
+  it('should stop rather than fall through to a later candidate', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    put('logan.config.json', '{ broken');
+    put('.loganrc', { level: 'error' });
+
+    // A broken file is a user error to surface, not a reason to quietly use
+    // something else.
+    expect(await loadConfigFromFile()).toEqual({});
+  });
+
+  it('should reject a non-object config', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    put('logan.config.json', [1, 2, 3]);
+
+    expect(await loadConfigFromFile()).toEqual({});
+    expect(warn.mock.calls[0][0]).toContain('object');
+  });
+
+  it('should distinguish an unreadable file from an absent one', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    put('logan.config.json', { level: 'warn' });
+    chmodSync(join(workspace, 'logan.config.json'), 0o000);
+
+    try {
+      const config = await loadConfigFromFile();
+
+      // Root ignores the mode bits; skip rather than assert something untrue.
+      if (warn.mock.calls.length > 0) {
+        expect(warn.mock.calls[0][0]).toContain('logan.config.json');
+        expect(config).toEqual({});
+      }
+    } finally {
+      chmodSync(join(workspace, 'logan.config.json'), 0o644);
+    }
+  });
+});
+
+describe('explicit configPath', () => {
+  it('should load exactly that file', async () => {
+    put('custom.json', { level: 'warn' });
+
+    expect(await loadConfigFromFile('custom.json')).toEqual({ level: LogLevel.WARN });
+  });
+
+  it('should throw when the file does not exist', async () => {
+    await expect(loadConfigFromFile('missing.json')).rejects.toThrow(/config file not found/);
+  });
+
+  it('should throw when the file is malformed', async () => {
+    put('custom.json', '{ broken');
+
+    await expect(loadConfigFromFile('custom.json')).rejects.toThrow(/is invalid/);
+  });
+
+  it('should not fall back to the candidate list', async () => {
+    put('logan.config.json', { level: 'debug' });
+
+    await expect(loadConfigFromFile('missing.json')).rejects.toThrow();
+  });
+});
+
+describe('value normalization', () => {
+  it('should convert a string level to the enum ordinal', async () => {
+    put('logan.config.json', { level: 'debug' });
+
+    const config = await loadConfigFromFile();
+
+    // A raw "debug" string makes every `level >= this.level` comparison NaN,
+    // which silently discards every record. This is the whole reason the
+    // loader normalizes rather than handing the parsed JSON straight over.
+    expect(config.level).toBe(LogLevel.DEBUG);
+    expect(typeof config.level).toBe('number');
+  });
+
+  it('should produce a logger that actually logs at the configured level', async () => {
+    put('logan.config.json', { level: 'debug' });
+    const lines: string[] = [];
+    for (const method of ['debug', 'info'] as const) {
+      vi.spyOn(console, method).mockImplementation((v: unknown) => {
+        lines.push(String(v));
+      });
+    }
+
+    const logger = createLogger({ ...(await loadConfigFromFile()), ignoreEnvironment: true });
+    logger.debug('visible');
+
+    expect(logger.getLevel()).toBe(LogLevel.DEBUG);
+    expect(lines).toHaveLength(1);
+  });
+
+  it('should accept a numeric level', async () => {
+    put('logan.config.json', { level: 2 });
+
+    expect((await loadConfigFromFile()).level).toBe(LogLevel.WARN);
+  });
+
+  it('should warn and drop an unrecognized level', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    put('logan.config.json', { level: 'verbose', format: 'json' });
+
+    const config = await loadConfigFromFile();
+
+    expect(config.level).toBeUndefined();
+    expect(config.format).toBe('json');
+    expect(warn.mock.calls[0][0]).toContain('level');
+  });
+
+  it('should warn and drop a mistyped field rather than pass it through', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    put('logan.config.json', { timestamp: 'yes', colorize: 1, metadata: 'nope', format: 'yaml' });
+
+    expect(await loadConfigFromFile()).toEqual({});
+    expect(warn).toHaveBeenCalledTimes(4);
+  });
+
+  it('should carry the fields it does understand', async () => {
+    put('logan.config.json', {
+      level: 'warn',
+      format: 'json',
+      timestamp: false,
+      colorize: true,
+      ignoreEnvironment: true,
+      metadata: { service: 'api' },
+      transports: [{ type: 'console', options: {} }],
+    });
+
+    expect(await loadConfigFromFile()).toEqual({
+      level: LogLevel.WARN,
+      format: 'json',
+      timestamp: false,
+      colorize: true,
+      ignoreEnvironment: true,
+      metadata: { service: 'api' },
+      transports: [{ type: 'console', options: {} }],
+    });
+  });
+});
+
+describe('precedence when applied explicitly', () => {
+  it('should be overridden by explicit config passed to createLogger', async () => {
+    put('logan.config.json', { level: 'debug' });
+
+    const fromFile = await loadConfigFromFile();
+    const logger = createLogger({ ...fromFile, level: LogLevel.ERROR, ignoreEnvironment: true });
+
+    expect(logger.getLevel()).toBe(LogLevel.ERROR);
+  });
+
+  it('should be overridden by the environment', async () => {
+    const saved = process.env.LOG_LEVEL;
+    put('logan.config.json', { level: 'debug' });
+    process.env.LOG_LEVEL = 'error';
+
+    try {
+      expect(createLogger(await loadConfigFromFile()).getLevel()).toBe(LogLevel.ERROR);
+    } finally {
+      if (saved === undefined) {
+        delete process.env.LOG_LEVEL;
+      } else {
+        process.env.LOG_LEVEL = saved;
+      }
+    }
+  });
+});

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -307,10 +307,12 @@ describe('Configuration System', () => {
       expect(config).toEqual({});
     });
 
-    it('should return empty config when files do not exist', async () => {
-      // This test will naturally return empty config since config files don't exist
-      const config = await loadConfigFromFile('non-existent-config.json');
-      expect(config).toEqual({});
+    it('should throw when an explicitly requested file does not exist', async () => {
+      // An explicit path that is missing is a caller mistake, not a reason to
+      // silently fall back to defaults.
+      await expect(loadConfigFromFile('non-existent-config.json')).rejects.toThrow(
+        /config file not found/
+      );
     });
 
     it('should search default config file paths', async () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,10 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
-    pool: 'vmThreads',
+    // Forks rather than VM threads: tests/config-file.test.ts uses
+    // process.chdir() to exercise config discovery against real directories,
+    // and chdir is unavailable in any worker-thread pool.
+    pool: 'forks',
     include: [
       'src/**/*.{test,spec}.{js,ts}',
       'tests/**/*.{test,spec}.{js,ts}'


### PR DESCRIPTION
Closes #58. Implements the plan on that issue.

## What was broken

Two independent defects made three of the four advertised config sources unreachable.

**The loop never iterated.** `return await loadNodeConfig(path)` returned unconditionally on the first pass, and `loadNodeConfig` swallowed every error and returned `{}` rather than throwing — so the loop's `catch` was dead code and `logan.config.js`, `.loganrc` and `package.json` were never consulted. Only `logan.config.json` had ever been read.

**`.loganrc` was unloadable anyway.** Dispatch was `path.endsWith('.json')` / `.endsWith('.js')`, and `.loganrc` matches neither, so it fell through to `return {}`.

Underneath both: `{}` meant three different things — "no config", "file absent", "file broken". Nothing could branch on the difference.

## The fix

A three-way outcome — `found` / `absent` / `invalid` — and a per-candidate table instead of extension sniffing:

| File | Read from |
|---|---|
| `logan.config.json` | the whole file |
| `.loganrc` | the whole file, as JSON |
| `package.json` | the `logan` key; a missing key counts as **absent** so the search continues |

- `absent` falls through, `found` returns, `invalid` **warns naming the path and stops** — a broken config file is a mistake to surface, not to route around.
- "File absent" and "file exists but cannot be read" are now distinguished. A permissions error no longer silently yields defaults.
- An explicit `configPath` is strict: a missing or malformed file **throws**. Asking for a specific file that is not there is a caller mistake.

## The defect the plan did not anticipate

Fixing the chain alone would have made things **worse**, not better.

A config file naturally writes `"level": "debug"` — a string, where the runtime expects a `LogLevel` ordinal. The old loader returned raw parsed JSON. Verified against the library:

```
records emitted with level:"debug" (a string): 0
LogLevel.INFO >= "debug"  ->  false
```

Every `level >= this.level` comparison becomes `NaN`, so **all logging is silently disabled**. The reproduction in #58's own body — `{"logan":{"level":"debug"}}` — would have gone from a silent no-op to a silent blackout.

So the loader now normalizes: `level` accepts the level names or a numeric ordinal, and every other field is type-checked. Anything unrecognized is dropped with a warning naming the file and field rather than handed to the logger to fail later. There is a test asserting a config file produces a logger that actually logs at the configured level.

## Please look at this one

**`logan.config.js` support is removed** — the plan recommended it and you approved, but the plan's reasoning ("dead code today, so it breaks nobody") was only three-quarters right.

The *default search* never reached `.js`, so that half breaks nobody. But an **explicit** `loadConfigFromFile('config.js')` bypassed the broken search and did work. So this is a narrow real break, not a pure no-op.

Removing it buys: no dynamic import executing a file from the working directory during logger construction, no `file://` cross-platform handling, no `@vite-ignore`, and — measurably — **the last `unanalyzable-dynamic-import` in the package is gone; `deno publish --dry-run` now reports zero warnings.**

If you would rather keep explicit `.js` opt-in and only drop it from the automatic search, say so and I will restore it — but the JSR warning comes back with it.

That break is also why this is `feat:` → **2.1.0** rather than a patch. Three config sources start working and one narrow path stops; minor is the honest bucket.

## Tests

`tests/config-file.test.ts` — 24 new tests against **real files in a real temp directory**, not a mocked `fs`. The bugs here were in path handling and control flow, which mocks paper over. Covers each candidate, fall-through, first-wins ordering, `package.json` without a `logan` key, malformed input, unreadable-vs-absent, explicit-path strictness, string and numeric levels, field rejection, and precedence under `createLogger`.

This needed `pool: 'forks'` in `vitest.config.ts` — the suite ran on `vmThreads`, and `process.chdir()` is unavailable in any worker-thread pool. (Note `vite.config.ts` also carries a `test` block; it is shadowed by `vitest.config.ts` and does nothing.)

262 tests pass, up from 245.

## Also in here

Per your note, folded in rather than run as its own PR: **`docs/maintenance-releases.md` now records that a merge to a non-default branch does not auto-close issues.** `Closes #N` in the merge to `1.x` was inert for #65 and #67 and I closed both by hand; the next maintenance release would have hit the same thing.

## Verification

```
vitest      262 passed | 7 skipped   (was 245)
tsc         clean
biome       clean
deno check  0 errors
publint     no problems
jsr         dry-run: 0 warnings  (was 1)
```

## Follow-up, deliberately not here

`createLogger()` stays synchronous, so file config is an explicit `createLogger(await loadConfigFromFile())` rather than an automatic link in the chain. An async `createLoggerAsync()` would close that gap, but it is a new public API and outside the approved plan.

Treering SPEC deliberately says nothing about config file discovery pending this decision (OQ-2). Now that it is settled, that spec section and its fixtures can be written.
